### PR TITLE
Fixed overflow after animation

### DIFF
--- a/frontend/app/utils/backgroundColor/index.tsx
+++ b/frontend/app/utils/backgroundColor/index.tsx
@@ -22,7 +22,8 @@ export function BackgroundColorProvider({
   const [color, setColor] = useState<string>("bg-strongblue");
 
   useEffect(() => {
-    document.body.className = color + " h-full flex flex-col grow";
+    document.body.className =
+      color + " overlow-x-hidden relative h-full flex flex-col grow";
   }, [color]);
 
   return (


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Innhold-g-r-ut-av-skjermbilde-p-b-de-h-yre-og-venstre-p-mobil-be031ee2e8444d2b8d371ff6014c9d3d?pvs=4)

## Beskrivelse.
Fikset at det var overflow etter animasjon, er nå overflow-x-hidden på body.  Er ennå mulig å scrolle ut hvis elementene faktisk overflower ved typ en veldig liten skjerm

## Skjermbilder.
