### PR TITLE
Fixed text-center on event.index, program.index, info.index

### DIFF
--- a/frontend/app/routes/($lang).event._index.tsx
+++ b/frontend/app/routes/($lang).event._index.tsx
@@ -42,7 +42,7 @@ export default function Events() {
   const params = useParams();
   return (
     <div className="flex grow flex-col items-center text-white relative">
-      <div className="flex flex-col items-center font-normal gap-4 text-xl py-12 px-0">
+      <div className="flex flex-col items-center font-normal text-center gap-4 text-xl py-12 px-0">
         {data.map((event, index) => (
           <div key={index}>
             <Link

--- a/frontend/app/routes/($lang).info._index.tsx
+++ b/frontend/app/routes/($lang).info._index.tsx
@@ -39,7 +39,7 @@ export default function Info() {
   return (
     <div className="flex flex-col grow items-center text-[#1B1C20] font-serif">
       <h1 className="text-5xl font-bold mb-12">{data?.title}</h1>
-      <div className="flex flex-col items-center font-normal gap-4 text-xl py-12 px-0">
+      <div className="flex flex-col items-center text-center font-normal gap-4 text-xl py-12 px-0">
         {data?.links?.map((link, index) => (
           <Link
             key={index}

--- a/frontend/app/routes/($lang).program._index.tsx
+++ b/frontend/app/routes/($lang).program._index.tsx
@@ -30,7 +30,7 @@ export default function Program() {
   return (
     <div className="flex flex-col grow items-center text-white relative">
       <h1 className="text-5xl font-bold mb-12">{data?.title}</h1>
-      <div className="flex flex-col items-center font-normal gap-4 text-xl py-12 px-0">
+      <div className="flex flex-col items-center font-normal text-center gap-4 text-xl py-12 px-0">
         {data?.gif && (
           <img
             src={gifUrl}


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Tekst-wrapper-rart-p-Info-og-Program-hvis-et-er-lengre-enn-20-chars-78bf084476a74766abbe8785b6ac81b1?pvs=4)

## Beskrivelse.
Fikset at liste over artikler eller event ikke var sentrert ved text-wrap

## Skjermbilder.
<img width="364" alt="image" src="https://github.com/user-attachments/assets/ca8beafe-258b-40aa-b7c7-b200fa4388de">

<img width="363" alt="image" src="https://github.com/user-attachments/assets/7e3b0bb6-942b-4e88-b38c-a6b15609a46b">

