### PR TITLE
Removed margin so header does not move

### DIFF
--- a/frontend/app/components/Header/Header.tsx
+++ b/frontend/app/components/Header/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
   return (
     <>
       {!frontpageUrl.includes(location.pathname) && (
-        <div className="sticky z-10 top-0 left-0 w-12 h-12 ml-4 mt-4">
+        <div className="sticky z-10 top-2 left-0 w-12 h-12 ml-4">
           <Link to={isEnglish ? "/en" : "/"}>
             <img src={isProgramPage ? WhiteLogo : BlackLogo} alt="Logo" />
           </Link>


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
[Lenke i Notion](https://www.notion.so/bekks/Kanban-9d75804e327947458fd2550b89b31775?p=a0cb2d0849844e1591c9c8c7f762a3a7&pm=s)
## Beskrivelse.
- Header sluttet å være sticky helt øverst av viewport. Fjernet margin-top. Nå er den sticky uansett.
## Skjermbilder.
