### PR TITLE
Remove heading portabletext

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -690,10 +690,6 @@
                     },
                     {
                       "type": "string",
-                      "value": "h1"
-                    },
-                    {
-                      "type": "string",
                       "value": "h2"
                     },
                     {

--- a/cms/schemaTypes/objects/RichTextEditor.ts
+++ b/cms/schemaTypes/objects/RichTextEditor.ts
@@ -7,7 +7,6 @@ export default {
       type: 'block',
       styles: [
         {title: 'Normal', value: 'normal'},
-        {title: 'Heading 1', value: 'h1'},
         {title: 'Heading 2', value: 'h2'},
         {title: 'Heading 3', value: 'h3'},
         {title: 'Heading 4', value: 'h4'},

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -111,9 +111,9 @@ export function getPortabletextStyle(colorCombination: string | undefined) {
     case "dayThemePeachBlue":
       return "text-black";
     case "nightThemePurpleWhite":
-      return "prose-h1:text-white prose-h2:text-white prose-h2:text-white prose-h3:text-white prose-h4:text-white prose-h5:text-white prose-h6:text-white prose-strong:text-white text-white";
+      return "prose-h2:text-white prose-h2:text-white prose-h3:text-white prose-h4:text-white prose-h5:text-white prose-h6:text-white prose-strong:text-white text-white";
     case "nightThemeBlueYellow":
-      return "prose-h1:text-white prose-h2:text-white prose-h2:text-white prose-h3:text-white prose-h4:text-white prose-h5:text-white prose-h6:text-white prose-strong:text-white text-white ";
+      return "prose-h2:text-white prose-h2:text-white prose-h3:text-white prose-h4:text-white prose-h5:text-white prose-h6:text-white prose-strong:text-white text-white ";
     default:
       return " text-black";
   }

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -126,7 +126,7 @@ export type Content = Array<{
     _type: "span";
     _key: string;
   }>;
-  style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  style?: "normal" | "h2" | "h3" | "h4" | "h5" | "h6";
   listItem?: "bullet" | "number";
   markDefs?: Array<{
     href?: string;
@@ -659,7 +659,7 @@ export type ARTICLE_QUERYResult = {
       _type: "span";
       _key: string;
     }>;
-    style?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+    style?: "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
     listItem?: "bullet" | "number";
     markDefs?: Array<{
       href?: string;
@@ -740,7 +740,7 @@ export type EVENT_QUERYResult = {
       _type: "span";
       _key: string;
     }>;
-    style?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+    style?: "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
     listItem?: "bullet" | "number";
     markDefs?: Array<{
       href?: string;


### PR DESCRIPTION
## Endringstype.
- Refaktorering.

## Linke til oppgave (Notion).
[Lenke i Notion](https://www.notion.so/bekks/Kanban-9d75804e327947458fd2550b89b31775?p=59280e959b86428b92a1a4644e88e38d&pm=s)
## Beskrivelse.
- Oppdatert RIchtexteditor slik at portableText ikke inneholder h1 tag. Fjernet h1 styling i textStyle.
## Skjermbilder.
