### PR TITLE
Bug 404

### DIFF
--- a/frontend/app/components/PageNotFound.tsx
+++ b/frontend/app/components/PageNotFound.tsx
@@ -10,6 +10,7 @@ export default function PageNotFound() {
       <Link
         to={language == "en" ? "/en" : "/"}
         className="text-xl underline mt-6"
+        reloadDocument
       >
         {t(texts.backToMain)}
       </Link>

--- a/frontend/app/components/PageNotFound.tsx
+++ b/frontend/app/components/PageNotFound.tsx
@@ -1,15 +1,14 @@
 import { useTranslation } from "../utils/i18n";
-import { Link, useParams } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 
 export default function PageNotFound() {
-  const { t } = useTranslation();
-  const params = useParams();
+  const { t, language } = useTranslation();
   return (
     <div className="h-screen bg-strongblue flex flex-col items-center justify-center text-white">
       <h1 className="text-6xl ">{t(texts.notFound)}</h1>
       <p className="mt-4n ">{t(texts.notFoundText)}</p>
       <Link
-        to={params.lang == "en" ? "/en" : "/"}
+        to={language == "en" ? "/en" : "/"}
         className="text-xl underline mt-6"
       >
         {t(texts.backToMain)}


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Tailwind-laster-ikke-inn-sporadisk-2cdbf3f3335648159639bd0dd630ad38?pvs=4)
[Lenke til Notion](https://www.notion.so/bekks/Back-to-Main-page-sendes-alltid-tilbake-til-norsk-side-ved-404-bc57d0e8d05d48d6b3ae1471209f9ec2?pvs=4)

## Beskrivelse.
Fikset at 404 på engelsk ikke riktig sendte bruker til engelsk forside. Fikset også at Tailwind ikke lastet inn riktig etter en error ved å force en reload etter en feilmelding hvis man klikker tilbake til hovedside.

## Skjermbilder.
