### PR TITLE
Fixed header not staying sticky

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -107,7 +107,7 @@ export default function App() {
       <BackgroundColorProvider>
         <SlugProvider>
           <motion.div
-            className="flex flex-col min-h-full"
+            className="flex flex-col min-h-[100vh]"
             key={pathname}
             initial={{ x: slideDirection * 100 + "%" }}
             animate={{ x: 0 }}

--- a/frontend/app/utils/backgroundColor/index.tsx
+++ b/frontend/app/utils/backgroundColor/index.tsx
@@ -23,7 +23,7 @@ export function BackgroundColorProvider({
 
   useEffect(() => {
     document.body.className =
-      color + " overlow-x-hidden relative h-full flex flex-col grow";
+      color + " overlow-x-hidden relative min-h-[100vh] flex flex-col grow";
   }, [color]);
 
   return (


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Header-setter-seg-fast-p-event-id-888b62265c6945268ce97ec6a4ae8750?pvs=4)

## Beskrivelse.
fikset at header ikke forble sticky. Dette var grunnet at html og body sin høyde ikke skalerte etter innholdet. Satte min-h-[100vh] for å la body vokse riktig. 

## Skjermbilder.
