### PR TITLE
Event image required

### DIFF
--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -66,7 +66,7 @@ export const eventType = defineType({
       description: 'SVG file av tittel',
       type: 'customImage',
       group: 'visual',
-      validation: (rule) => [rule.required().error('Grafisk tittel er påkrevd')],
+      validation: (rule) => [rule.required().assetRequired().error('Grafisk tittel er påkrevd')],
       options: {
         accept: '.svg',
       },
@@ -131,7 +131,7 @@ export const eventType = defineType({
       options: {
         hotspot: true,
       },
-      validation: (rule) => [rule.required().error('Bilde er påkrevd.')],
+      validation: (rule) => [rule.required().assetRequired().error('Bilde er påkrevd.')],
     }),
     defineField({
       name: 'text',

--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -131,6 +131,7 @@ export const eventType = defineType({
       options: {
         hotspot: true,
       },
+      validation: (rule) => [rule.required().error('Bilde er påkrevd.')],
     }),
     defineField({
       name: 'text',

--- a/cms/schemaTypes/objects/customImage.ts
+++ b/cms/schemaTypes/objects/customImage.ts
@@ -7,6 +7,7 @@ export default {
   options: {
     hotspot: true,
   },
+
   fields: [
     defineField({
       title: 'Alternativ Tekst',


### PR DESCRIPTION
## Endringstype.
- Bugfix.
- Ny funksjonalitet.

## Link til oppgave (Notion).

https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=24f7d2aac7cd406a873f36481769f489&pm=s

https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=779c6e63564c4ceea1de3ba1f8914eb6&pm=s

## Beskrivelse.
Stort eventbilde skulle være required.
Måtte legge til assetRequired() på stedene som brukte customImage hvor bilde skulle være påkrevd. AssetRequired er mer spesifikt enn required, og krever at en faktisk asset er referert for å bli gyldig. Tidligere ble det gyldig hvis man bare hadde bildeteksten og ikke bilde f.eks.

## Skjermbilder.
![image](https://github.com/user-attachments/assets/a81de242-de5d-42d0-8d26-f68eea719bef)
