### PR TITLE
Fritekst vaskelapper

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -3047,6 +3047,16 @@
         },
         "optional": false
       },
+      "labels": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "string"
+          }
+        },
+        "optional": true
+      },
       "dates": {
         "type": "objectAttribute",
         "value": {

--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -72,6 +72,22 @@ export const eventType = defineType({
       },
     }),
     defineField({
+      name: 'labels',
+      title: 'Vaskelapper',
+      description: 'Tagger som kommer i bokser under tittel',
+      type: 'array',
+      group: 'content',
+      of: [
+        {
+          type: 'string',
+          validation: (rule) => [
+            rule.required().min(2).error(`Minimum lengde 2 tegn`),
+            rule.max(20).warning('Anbefaler kortere tekst.'),
+          ],
+        },
+      ],
+    }),
+    defineField({
       name: 'dates',
       title: 'Datoer',
       type: 'array',

--- a/frontend/app/components/EventLabels.tsx
+++ b/frontend/app/components/EventLabels.tsx
@@ -20,6 +20,7 @@ type Props = {
   textColor?: string;
   textColorBorder?: string;
   genre?: EventGenre | null;
+  customLabels: null | string[];
 };
 
 export function formatDateOnly(dateString: string): string {
@@ -74,6 +75,7 @@ export const EventLabels = ({
   secondaryBorder,
   textColor,
   textColorBorder,
+  customLabels,
 }: Props) => {
   const { language, t } = useTranslation();
 
@@ -111,7 +113,12 @@ export const EventLabels = ({
       : "";
   };
 
-  const labels = [dateLabel, formattedTimestamp, getGenre()];
+  const labels = [
+    ...(customLabels ?? []),
+    dateLabel,
+    formattedTimestamp,
+    getGenre(),
+  ];
 
   const handleScroll = () => {
     const target = document.getElementById("tickets");
@@ -124,7 +131,7 @@ export const EventLabels = ({
     <>
       <div
         id="eventLabels"
-        className="flex flex-wrap gap-4 md:float-start font-serif justify-start"
+        className="flex flex-wrap gap-4 md:float-start uppercase font-serif justify-start"
       >
         {labels.map(
           (label, index) =>

--- a/frontend/app/queries/event-queries.ts
+++ b/frontend/app/queries/event-queries.ts
@@ -43,6 +43,7 @@ export async function getEvent(params: Params<string>) {
     imageMask, 
     colorCombinationsNight, 
     dates, 
+    labels,
     text[]{..., _type=="video" => {title, muxVideo{asset->{playbackId}}}},
     eventGenre, 
     roleGroups[]{

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -152,6 +152,7 @@ export default function Event() {
         {data.dates && (
           <EventLabels
             dateObj={data.dates}
+            customLabels={data.labels}
             genre={data.eventGenre}
             primaryText={primaryText}
             secondaryBgColor={secondaryBgColor}

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -114,7 +114,7 @@ export type RoleGroups = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "person";
     };
-    occupation?: string;
+    occupation: string;
     _key: string;
   }>;
 };
@@ -528,6 +528,7 @@ export type Event = {
     alt: string;
     _type: "customImage";
   };
+  labels?: Array<string>;
   dates: Array<{
     date: string;
     url: string;
@@ -693,7 +694,7 @@ export type EVENTS_QUERYResult = Array<{
   title: string;
 }>;
 // Variable: EVENT_QUERY
-// Query: *[_type=="event" && language==$lang && slug.current==$id][0]{    metaTitle,    metaDescription,    title,     image,    imageMask,     colorCombinationsNight,     dates,     text[]{..., _type=="video" => {title, muxVideo{asset->{playbackId}}}},    eventGenre,     roleGroups[]{      name,       persons[]{      occupation,       person->{name, image, text}      }    },    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{    slug,    language,    }  }
+// Query: *[_type=="event" && language==$lang && slug.current==$id][0]{    metaTitle,    metaDescription,    title,     image,    imageMask,     colorCombinationsNight,     dates,     labels,    text[]{..., _type=="video" => {title, muxVideo{asset->{playbackId}}}},    eventGenre,     roleGroups[]{      name,       persons[]{      occupation,       person->{name, image, text}      }    },    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{    slug,    language,    }  }
 export type EVENT_QUERYResult = {
   metaTitle: MetaTitle;
   metaDescription: MetaDescription;
@@ -718,6 +719,7 @@ export type EVENT_QUERYResult = {
     status: 1 | 2 | 3;
     _key: string;
   }>;
+  labels: Array<string> | null;
   text: Array<{
     _ref: string;
     _type: "reference";
@@ -754,7 +756,7 @@ export type EVENT_QUERYResult = {
   roleGroups: Array<{
     name: string;
     persons: Array<{
-      occupation: string | null;
+      occupation: string;
       person: {
         name: string;
         image: {


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Link til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=ed23e72464b643cdb6ed14513997e224&pm=s

## Beskrivelse.
Har lagt til muligheten til å lage custom-labels med fritekst for eventer.

## Skjermbilder.
![image](https://github.com/user-attachments/assets/8921537a-57ff-456c-907d-80e1860a78f9)
![image](https://github.com/user-attachments/assets/94fe0d31-7182-4fcf-887b-03cc30e02e98)

