### PR TITLE
Add skip to main main content button, that is the first element focused when tabbing on the page.

### DIFF
--- a/frontend/app/components/Header/Header.tsx
+++ b/frontend/app/components/Header/Header.tsx
@@ -15,11 +15,19 @@ export default function Header() {
   return (
     <>
       {!frontpageUrl.includes(location.pathname) && (
-        <div className="sticky z-10 top-2 left-0 w-12 h-12 ml-4">
-          <Link to={isEnglish ? "/en" : "/"} aria-label={t(texts.goToMain)}>
-            <img src={isProgramPage ? WhiteLogo : BlackLogo} alt="Logo" />
-          </Link>
-        </div>
+        <>
+          <a
+            href="#main"
+            className="absolute -left-96 self-start top-auto overflow-hidden focus:static focus:h-auto bg-white"
+          >
+            {t(texts.goToMainContent)}
+          </a>
+          <div className="sticky z-10 top-2 left-0 w-12 h-12 ml-4">
+            <Link to={isEnglish ? "/en" : "/"} aria-label={t(texts.goToMain)}>
+              <img src={isProgramPage ? WhiteLogo : BlackLogo} alt="Logo" />
+            </Link>
+          </div>
+        </>
       )}
     </>
   );
@@ -29,5 +37,9 @@ const texts = createTexts({
   goToMain: {
     en: " Go to main page",
     nb: " Gå til hovedsiden",
+  },
+  goToMainContent: {
+    en: "Skip to main content",
+    nb: "Hopp til hovedinnhold",
   },
 });

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -120,7 +120,9 @@ export default function App() {
               duration: 0.5,
             }}
           >
-            <Outlet />
+            <div id="main">
+              <Outlet />
+            </div>
           </motion.div>
           <StickyFooter infoUrl="/info" programUrl="/program" />
         </SlugProvider>


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=84e9b7c13caa4a2a95858a08ab72ec86&pm=s

## Beskrivelse.
UU-krav sier at det skal være en "hopp til hovedinnholdet"-knapp.  Denne er bare synlig når man navigerer til den ved tabbing.
https://www.uutilsynet.no/wcag-standarden/241-hoppe-over-blokker-niva/103

## Skjermbilder.
![image](https://github.com/user-attachments/assets/7430a8f0-2857-478c-9403-a6a293999dbf)

