### PR TITLE
Refaktorering for å fikse typegenereringsfeil

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -3103,7 +3103,7 @@
                 },
                 "dereferencesTo": "sanity.imageAsset"
               },
-              "optional": true
+              "optional": false
             },
             "hotspot": {
               "type": "objectAttribute",
@@ -3247,7 +3247,7 @@
                 },
                 "dereferencesTo": "sanity.imageAsset"
               },
-              "optional": true
+              "optional": false
             },
             "hotspot": {
               "type": "objectAttribute",
@@ -3281,7 +3281,7 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       },
       "text": {
         "type": "objectAttribute",

--- a/frontend/app/queries/article-queries.ts
+++ b/frontend/app/queries/article-queries.ts
@@ -2,30 +2,29 @@ import { Params } from "@remix-run/react";
 import groq from "groq";
 
 export function getArticlesQuery(params: Params<string>) {
-  if (!params.lang) {
-    params = { lang: "nb" };
-  }
-  const ARTICLES_QUERY = groq`*[_type=="article" && language=="${params.lang}"]{_id, slug, title}`;
-  return ARTICLES_QUERY;
+  const lang = params.lang ?? "nb";
+  const ARTICLES_QUERY = groq`*[_type=="article" && language==$lang]{_id, slug, title}`;
+  return { query: ARTICLES_QUERY, params: { lang } };
 }
 
 export function getArticleQuery(params: Params<string>) {
-  const articleID = params.id;
+  const id = params.id;
+  const lang = params.lang ?? "nb";
 
   try {
-    if (!articleID) {
+    if (!id) {
       throw new Response("Event ID is required", { status: 404 });
     }
     if (params.id == "noSlugFound") {
-      return "No translation with this slug";
+      throw new Response("No translation found for this slug", { status: 404 });
     }
     if (!params.lang) {
-      params = { lang: "nb", id: articleID };
+      params = { lang: "nb", id: id };
     }
   } catch (error) {
     throw new Error("Params not found");
   }
-  const ARTICLE_QUERY = groq`*[_type=="article" && slug.current=="${params.id}" && language=="${params.lang}"][0]{
+  const ARTICLE_QUERY = groq`*[_type=="article" && slug.current==$id && language==$lang][0]{
     title, 
     slug, 
     metaTitle, 
@@ -51,5 +50,5 @@ export function getArticleQuery(params: Params<string>) {
       language,
       }
     }`;
-  return ARTICLE_QUERY;
+  return { query: ARTICLE_QUERY, params: { lang, id } };
 }

--- a/frontend/app/queries/event-queries.ts
+++ b/frontend/app/queries/event-queries.ts
@@ -1,29 +1,31 @@
 import { Params } from "@remix-run/react";
 import groq from "groq";
 
-export function getEventsQuery (params: Params<string>){
-  const EVENTS_QUERY = groq`*[_type=="event" && language=="${params.lang}"]{_id, slug, title}`;
-  return EVENTS_QUERY;
+export function getEventsQuery(params: Params<string>) {
+  const lang = params.lang ?? "nb";
+  const EVENTS_QUERY = groq`*[_type=="event" && language==$lang]{_id, slug, title}`;
+  return { query: EVENTS_QUERY, params: { lang } };
 }
 
 export function getEventQuery(params: Params<string>) {
-  const eventId = params.id;
+  const id = params.id;
+  const lang = params.lang ?? "nb";
   try {
-    if (!eventId) {
+    if (!id) {
       throw new Response("Event ID is required", { status: 404 });
     }
 
-    if (eventId == "noSlugFound") {
-      return "No translation with this slug";
+    if (id == "noSlugFound") {
+      throw new Response("No event found for this slug", { status: 404 });
     }
 
     if (!params.lang) {
-      params = { lang: "nb", id: eventId };
+      params = { lang: "nb", id: id };
     }
   } catch (error) {
     throw new Error("Params not found");
   }
-  const EVENT_QUERY = groq`*[_type=="event" && language=="${params.lang}" && slug.current=="${params.id}"][0]{
+  const EVENT_QUERY = groq`*[_type=="event" && language==$lang && slug.current==$id][0]{
     metaTitle,
     metaDescription,
     title, 
@@ -47,5 +49,5 @@ export function getEventQuery(params: Params<string>) {
     }
   }`;
 
-  return EVENT_QUERY;
+  return { query: EVENT_QUERY, params: { lang, id } };
 }

--- a/frontend/app/queries/frontpage-queries.ts
+++ b/frontend/app/queries/frontpage-queries.ts
@@ -2,10 +2,9 @@ import { Params } from "@remix-run/react";
 import groq from "groq";
 
 export function getFrontpageQuery(params: Params<string>) {
-  if (!params.lang) {
-    params = { lang: "nb" };
-  }
-  const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="${params.lang}"][0]{
+  const lang = params.lang ?? "nb";
+
+  const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language==$lang][0]{
   title, 
   image, 
   language,
@@ -23,5 +22,5 @@ export function getFrontpageQuery(params: Params<string>) {
     }
   }`;
 
-  return FRONTPAGE_QUERY;
+  return { query: FRONTPAGE_QUERY, params: { lang } };
 }

--- a/frontend/app/queries/info-queries.ts
+++ b/frontend/app/queries/info-queries.ts
@@ -2,9 +2,7 @@ import { Params } from "@remix-run/react";
 import groq from "groq";
 
 export function getInfoPageQuery(params: Params<string>) {
-  if (!params.lang) {
-    params = { lang: "nb" };
-  }
-  const INFOPAGE_QUERY = groq`*[_type=="infopage" && language=="${params.lang}"]{title, metaTitle, metaDescription, links[]->{_type, title, slug}}[0]`;
-  return INFOPAGE_QUERY;
+  const lang = params.lang ?? "nb";
+  const INFOPAGE_QUERY = groq`*[_type=="infopage" && language==$lang]{title, metaTitle, metaDescription, links[]->{_type, title, slug}}[0]`;
+  return { query: INFOPAGE_QUERY, params: { lang } };
 }

--- a/frontend/app/queries/program-queries.ts
+++ b/frontend/app/queries/program-queries.ts
@@ -2,11 +2,7 @@ import { Params } from "@remix-run/react";
 import groq from "groq";
 
 export function getProgramPageQuery(params: Params<string>) {
-  if (!params.lang) {
-    params = { lang: "nb" };
-  }
-  const PROGRAMPAGE_QUERY = groq`*[_type=="programpage" && language=="${params.lang}"]{metaTitle, metaDescription, title, text,gif, links[]->{title, slug}}[0]`;
-
-  return PROGRAMPAGE_QUERY;
+  const lang = params.lang ?? "nb";
+  const PROGRAMPAGE_QUERY = groq`*[_type=="programpage" && language==$lang]{metaTitle, metaDescription, title, text,gif, links[]->{title, slug}}[0]`;
+  return { query: PROGRAMPAGE_QUERY, params: { lang } };
 }
-

--- a/frontend/app/routes/($lang)._index.tsx
+++ b/frontend/app/routes/($lang)._index.tsx
@@ -14,8 +14,8 @@ import { loadQuery } from "../../sanity/loader.server";
 import { useQuery } from "../../sanity/loader";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const query = getFrontpageQuery(params);
-  const initial = await loadQuery<FRONTPAGE_QUERYResult>(query, params);
+  const { query, params: queryParams } = getFrontpageQuery(params);
+  const initial = await loadQuery<FRONTPAGE_QUERYResult>(query, queryParams);
   const event = initial.data;
 
   if (!event) {
@@ -30,7 +30,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  return { initial, query: query, queryParams: params };
+  return { initial, query: query, queryParams: queryParams };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data, location }) => {

--- a/frontend/app/routes/($lang).artikler.$id.tsx
+++ b/frontend/app/routes/($lang).artikler.$id.tsx
@@ -15,8 +15,11 @@ import { QueryResponseInitial } from "@sanity/react-loader";
 import { useQuery } from "../../sanity/loader";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const query = getArticleQuery(params);
-  const initial = await loadQuery<Custom_ARTICLE_QUERYResult>(query, params);
+  const { query, params: queryParams } = getArticleQuery(params);
+  const initial = await loadQuery<Custom_ARTICLE_QUERYResult>(
+    query,
+    queryParams
+  );
   const article = initial.data;
 
   if (!article) {
@@ -31,7 +34,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  return { initial, query: query, params: params };
+  return { initial, query: query, queryParams: queryParams };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
@@ -79,13 +82,13 @@ export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
 };
 
 export default function Article() {
-  const { initial, query, params } = useLoaderData<typeof loader>() as {
+  const { initial, query, queryParams } = useLoaderData<typeof loader>() as {
     initial: QueryResponseInitial<Custom_ARTICLE_QUERYResult>;
     query: string;
-    params: Record<string, string>;
+    queryParams: Record<string, string>;
   };
 
-  const { data } = useQuery<typeof initial.data>(query, params, {
+  const { data } = useQuery<typeof initial.data>(query, queryParams, {
     initial,
   });
 

--- a/frontend/app/routes/($lang).artikler._index.tsx
+++ b/frontend/app/routes/($lang).artikler._index.tsx
@@ -9,8 +9,8 @@ import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
 import { createTexts, useTranslation } from "../utils/i18n";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const query = getArticlesQuery(params);
-  const initial = await loadQuery<ARTICLES_QUERYResult>(query, params);
+  const { query, params: queryParams } = getArticlesQuery(params);
+  const initial = await loadQuery<ARTICLES_QUERYResult>(query, queryParams);
   const articles = initial.data;
 
   if (!articles) {
@@ -19,7 +19,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  return { initial, query: query, sanityParams: params };
+  return { initial, query: query, queryParams: queryParams };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
@@ -65,13 +65,13 @@ export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
 };
 
 export default function Articles() {
-  const { initial, query, sanityParams } = useLoaderData<typeof loader>() as {
+  const { initial, query, queryParams } = useLoaderData<typeof loader>() as {
     initial: QueryResponseInitial<ARTICLES_QUERYResult>;
     query: string;
-    sanityParams: Record<string, string>;
+    queryParams: Record<string, string>;
   };
 
-  const { data } = useQuery<typeof initial.data>(query, sanityParams, {
+  const { data } = useQuery<typeof initial.data>(query, queryParams, {
     initial,
   });
   const params = useParams();

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -20,8 +20,8 @@ import { loadQuery } from "../../sanity/loader.server";
 import { useQuery } from "../../sanity/loader";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const query = getEventQuery(params);
-  const initial = await loadQuery<Custom_EVENT_QUERYResult>(query, params);
+  const { query, params: queryParams } = getEventQuery(params);
+  const initial = await loadQuery<Custom_EVENT_QUERYResult>(query, queryParams);
   const event = initial.data;
 
   if (!event) {
@@ -30,7 +30,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  return { initial, query: query, params: params };
+  return { initial, query: query, queryParams: queryParams };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
@@ -76,13 +76,13 @@ export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
 };
 
 export default function Event() {
-  const { initial, query, params } = useLoaderData<typeof loader>() as {
+  const { initial, query, queryParams } = useLoaderData<typeof loader>() as {
     initial: QueryResponseInitial<Custom_EVENT_QUERYResult>;
     query: string;
-    params: Record<string, string>;
+    queryParams: Record<string, string>;
   };
 
-  const { data } = useQuery<typeof initial.data>(query, params, {
+  const { data } = useQuery<typeof initial.data>(query, queryParams, {
     initial,
   });
 

--- a/frontend/app/routes/($lang).event._index.tsx
+++ b/frontend/app/routes/($lang).event._index.tsx
@@ -11,8 +11,8 @@ import { loadQuery } from "../../sanity/loader.server";
 import { useQuery } from "../../sanity/loader";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const query = getEventsQuery(params);
-  const initial = await loadQuery<EVENTS_QUERYResult>(query, params);
+  const { query, params: queryParams } = getEventsQuery(params);
+  const initial = await loadQuery<EVENTS_QUERYResult>(query, queryParams);
   const event = initial.data;
 
   if (!event) {
@@ -21,7 +21,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  return { initial, query: query, params: params };
+  return { initial, query: query, queryParams: queryParams };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ location }) => {
@@ -58,16 +58,12 @@ export const meta: MetaFunction<typeof loader> = ({ location }) => {
 };
 
 export default function Events() {
-  const {
-    initial,
-    query,
-    params: params,
-  } = useLoaderData<typeof loader>() as {
+  const { initial, query, queryParams } = useLoaderData<typeof loader>() as {
     initial: QueryResponseInitial<EVENTS_QUERYResult>;
     query: string;
-    params: Record<string, string>;
+    queryParams: Record<string, string>;
   };
-  const { data } = useQuery<typeof initial.data>(query, params, {
+  const { data } = useQuery<typeof initial.data>(query, queryParams, {
     initial,
   });
 

--- a/frontend/app/routes/($lang).info._index.tsx
+++ b/frontend/app/routes/($lang).info._index.tsx
@@ -10,8 +10,8 @@ import { QueryResponseInitial } from "@sanity/react-loader";
 import { useQuery } from "../../sanity/loader";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const query = getInfoPageQuery(params);
-  const initial = await loadQuery<INFOPAGE_QUERYResult>(query, params);
+  const { query, params: queryParams } = getInfoPageQuery(params);
+  const initial = await loadQuery<INFOPAGE_QUERYResult>(query, queryParams);
   const informationPage = initial.data;
 
   if (!informationPage) {
@@ -20,7 +20,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  return { initial, query: query, sanityParams: params };
+  return { initial, query: query, queryParams: queryParams };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
@@ -69,12 +69,12 @@ function RedirectType(type: string) {
 }
 
 export default function Info() {
-  const { initial, query, sanityParams } = useLoaderData<typeof loader>() as {
+  const { initial, query, queryParams } = useLoaderData<typeof loader>() as {
     initial: QueryResponseInitial<INFOPAGE_QUERYResult>;
     query: string;
-    sanityParams: Record<string, string>;
+    queryParams: Record<string, string>;
   };
-  const { data } = useQuery<typeof initial.data>(query, sanityParams, {
+  const { data } = useQuery<typeof initial.data>(query, queryParams, {
     initial,
   });
 

--- a/frontend/app/routes/($lang).program._index.tsx
+++ b/frontend/app/routes/($lang).program._index.tsx
@@ -12,8 +12,8 @@ import { QueryResponseInitial } from "@sanity/react-loader";
 import { useQuery } from "../../sanity/loader";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const query = getProgramPageQuery(params);
-  const initial = await loadQuery<PROGRAMPAGE_QUERYResult>(query, params);
+  const { query, params: queryParams } = getProgramPageQuery(params);
+  const initial = await loadQuery<PROGRAMPAGE_QUERYResult>(query, queryParams);
   const programPage = initial.data;
 
   if (!programPage) {
@@ -22,7 +22,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  return { initial, query: query, sanityParams: params };
+  return { initial, query: query, queryParams: queryParams };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ location, data }) => {
@@ -59,13 +59,13 @@ export const meta: MetaFunction<typeof loader> = ({ location, data }) => {
 };
 
 export default function Program() {
-  const { initial, query, sanityParams } = useLoaderData<typeof loader>() as {
+  const { initial, query, queryParams } = useLoaderData<typeof loader>() as {
     initial: QueryResponseInitial<PROGRAMPAGE_QUERYResult>;
     query: string;
-    sanityParams: Record<string, string>;
+    queryParams: Record<string, string>;
   };
 
-  const { data } = useQuery<typeof initial.data>(query, sanityParams, {
+  const { data } = useQuery<typeof initial.data>(query, queryParams, {
     initial,
   });
   const { setColor } = useBackgroundColor();

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -533,7 +533,7 @@ export type Event = {
   imageMask?: ImageMask;
   slug: Slug;
   svgTitle: {
-    asset?: {
+    asset: {
       _ref: string;
       _type: "reference";
       _weak?: boolean;
@@ -552,8 +552,8 @@ export type Event = {
     _key: string;
   }>;
   duration: string;
-  image?: {
-    asset?: {
+  image: {
+    asset: {
       _ref: string;
       _type: "reference";
       _weak?: boolean;
@@ -635,7 +635,7 @@ export type ARTICLES_QUERYResult = Array<{
   title: string;
 }>;
 // Variable: ARTICLE_QUERY
-// Query: *[_type=="article" && slug.current==$id && language==$lang][0]{    title,     slug,     metaTitle,     metaDescription,     colorCombinationsDay,     image,     text[]{...,       _type=="video" => {        title, muxVideo{asset->{playbackId}        }      }    },     video{      title,       muxVideo{        asset->{          playbackId}        }    },    'event': event->{slug},    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{      slug,      language,      }    }
+// Query: *[_type=="article" && slug.current=="$id" && language=="$lang"][0]{    title,     slug,     metaTitle,     metaDescription,     colorCombinationsDay,     image,     text[]{...,       _type=="video" => {        title, muxVideo{asset->{playbackId}        }      }    },     video{      title,       muxVideo{        asset->{          playbackId}        }    },    'event': event->{slug},    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{      slug,      language,      }    }
 export type ARTICLE_QUERYResult = {
   title: string;
   slug: Slug;
@@ -710,13 +710,13 @@ export type EVENTS_QUERYResult = Array<{
   title: string;
 }>;
 // Variable: EVENT_QUERY
-// Query: *[_type=="event" && language==$lang && slug.current==$id][0]{    metaTitle,    metaDescription,    title,     image,    imageMask,     colorCombinationsNight,     dates,     labels,    text[]{..., _type=="video" => {title, muxVideo{asset->{playbackId}}}},    eventGenre,     roleGroups[]{      name,       persons[]{      occupation,       person->{name, image, text}      }    },    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{    slug,    language,    }  }
+// Query: *[_type=="event" && language=="$lang" && slug.current=="$id}"][0]{    metaTitle,    metaDescription,    title,     image,    imageMask,     colorCombinationsNight,     dates,     labels,    text[]{..., _type=="video" => {title, muxVideo{asset->{playbackId}}}},    eventGenre,     roleGroups[]{      name,       persons[]{      occupation,       person->{name, image, text}      }    },    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{    slug,    language,    }  }
 export type EVENT_QUERYResult = {
   metaTitle: MetaTitle;
   metaDescription: MetaDescription;
   title: string;
   image: {
-    asset?: {
+    asset: {
       _ref: string;
       _type: "reference";
       _weak?: boolean;
@@ -726,7 +726,7 @@ export type EVENT_QUERYResult = {
     crop?: SanityImageCrop;
     alt: string;
     _type: "customImage";
-  } | null;
+  };
   imageMask: ImageMask | null;
   colorCombinationsNight: ColorCombinationsNight;
   dates: Array<{
@@ -835,7 +835,7 @@ export type FRONTPAGE_QUERYResult = {
     title: string;
     text: Content | null;
     image: {
-      asset?: {
+      asset: {
         _ref: string;
         _type: "reference";
         _weak?: boolean;
@@ -845,12 +845,12 @@ export type FRONTPAGE_QUERYResult = {
       crop?: SanityImageCrop;
       alt: string;
       _type: "customImage";
-    } | null;
+    };
     slug: Slug;
     metaTitle: MetaTitle;
     metaDescription: MetaDescription;
     svgTitle: {
-      asset?: {
+      asset: {
         _ref: string;
         _type: "reference";
         _weak?: boolean;


### PR DESCRIPTION

## Endringstype.
- Bugfix.
- Refaktorering.

## Link til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=3ac94aa3409a4630b9b7a40a2ae6e523&pm=s

## Beskrivelse.

Når vi kjørte denne kommandoen
`$ npx sanity typegen generate`
fikk vi følgende feilmelding:

`
- Generating types
× Unsupported expression type: MemberExpression in ../frontend/app/queries/article-queries.ts:8:65 in "../frontend/app/queries/article-queries.ts"
× Unsupported expression type: MemberExpression in ../frontend/app/queries/event-queries.ts:5:61 in "../frontend/app/queries/event-queries.ts"
× Unsupported expression type: MemberExpression in ../frontend/app/queries/frontpage-queries.ts:8:68 in "../frontend/app/queries/frontpage-queries.ts"
× Unsupported expression type: MemberExpression in ../frontend/app/queries/info-queries.ts:8:66 in "../frontend/app/queries/info-queries.ts"
× Unsupported expression type: MemberExpression in ../frontend/app/queries/program-queries.ts:8:72 in "../frontend/app/queries/program-queries.ts"
‼ Encountered errors in 5 files while generating types
√ Generated TypeScript types for 42 schema types and 0 GROQ queries in 0 files into: ../frontend/sanity/types.ts`

Problemet lå i måten å skrive queries på. Eksempel:

 const EVENTS_QUERY = groq`*[_type=="event" && language=="${params.lang}"]{_id, slug, title}`;

Typescript klagde på logisk deklarering i query. I typescript må groq queries skrives som en string for at den skal klare å generere typer. Da blir det slik:

  const EVENTS_QUERY = groq`*[_type=="event" && language==$lang]{_id, slug, title}`;

Den klagde videre på at parametere ikke ble sendt inn riktig. For å fikse dette måtte vi endre på hva som returneres fra queries og hva som hentes ut fra queries i loader.

I loader henter vi nå ut  {query, params} fra queriene, og i queriene så returnerer vi parametere.
Slik:
  return { query: QUERY, params: { lang, id } };

