### PR TITLE
Fixed mux-feil

### DIFF
--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -5,6 +5,7 @@ import urlFor from "../utils/imageUrlBuilder";
 import { QuoteComponent } from "./QuoteComponent";
 import { ReviewComponent } from "./ReviewComponent";
 import { ExpandableBlockComponent } from "./ExpandableBlockComponent";
+import { stegaClean } from "@sanity/client/stega";
 
 interface QuoteStyle {
   styleBlock?: string;
@@ -49,7 +50,7 @@ export default function PortableTextComponent({
         return value.muxVideo.asset ? (
           <MuxPlayer
             disableCookies={true}
-            playbackId={value.muxVideo.asset.playbackId}
+            playbackId={stegaClean(value.muxVideo.asset.playbackId)}
             metadata={value.title ? { video_title: value.title } : undefined}
           />
         ) : null;


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Beskrivelse.
Videoer lastet opp via mux-plugin ble ikke vist på siden.
Viste seg at det ble lagt til noen ekstra tegn med id-en. La til stega-clean rundt id som løste det.
