### PR TITLE
Loosen cookie policy, since sanity and remix aren't hosted on the same url in production.

### DIFF
--- a/frontend/app/sessions.ts
+++ b/frontend/app/sessions.ts
@@ -11,7 +11,7 @@ const { getSession, commitSession, destroySession } =
     cookie: {
       name: PREVIEW_SESSION_NAME,
       secrets: [process.env.SANITY_SESSION_SECRET],
-      sameSite: "lax",
+      sameSite: "none",
     },
   });
 


### PR DESCRIPTION
Ideally they should be, but for now, just loosen cookie policy.

## Endringstype.
- Refaktorering.
