### PR TITLE
Set cookie secure attribute to true

### DIFF
--- a/frontend/app/sessions.ts
+++ b/frontend/app/sessions.ts
@@ -12,6 +12,7 @@ const { getSession, commitSession, destroySession } =
       name: PREVIEW_SESSION_NAME,
       secrets: [process.env.SANITY_SESSION_SECRET],
       sameSite: "none",
+      secure: true,
     },
   });
 


### PR DESCRIPTION
This ensures that the cookie is only sendt over https, which is required when sameSite is none by some browsers.
