### PR TITLE
Redirect to current url after exiting preview.

### DIFF
--- a/app/components/ExitPreview.tsx
+++ b/app/components/ExitPreview.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "~/utils/i18n";
 
@@ -6,8 +7,8 @@ export function ExitPreview() {
   useEffect(() => {
     setInIframe(window.self !== window.top);
   }, []);
-  const {t} = useTranslation();
-
+  const { t } = useTranslation();
+  const location = useLocation();
 
   return inIframe ? null : (
     <div className="pointer-events-none fixed z-50 inset-0 flex h-screen w-screen items-end justify-end p-2">
@@ -16,11 +17,12 @@ export function ExitPreview() {
         action="/resource/preview"
         method="POST"
       >
+        <input type="hidden" name="redirectUrl" value={location.pathname} />
         <button
           className="bg-black p-4 leading-none font-bold text-white"
           type="submit"
         >
-          {t(exitText.tickets)}
+          {t(exitText.buttonText)}
         </button>
       </form>
     </div>
@@ -28,7 +30,7 @@ export function ExitPreview() {
 }
 
 const exitText = {
-  tickets: {
+  buttonText: {
     en: "Exit preview mode",
     nb: "Avlsutt forhåndsvisning",
   },

--- a/app/routes/resource.preview.ts
+++ b/app/routes/resource.preview.ts
@@ -14,10 +14,12 @@ export const action: ActionFunction = async ({ request }) => {
   if (request.method !== "POST") {
     return json({ message: "Method not allowed" }, 405);
   }
+  const formData = await request.formData();
+  const redirectUrl = formData.get("redirectUrl") as string;
 
   const session = await getSession(request.headers.get("Cookie"));
 
-  return redirect("/", {
+  return redirect(redirectUrl ?? "/", {
     headers: {
       "Set-Cookie": await destroySession(session),
     },


### PR DESCRIPTION
Add parameter to exit preview button, so that the user can be redirected back, after the preview cookie is deleted.

Previously the user was always redirected to the frontpage.