### PR TITLE
Fix error with when running sanity schema extract.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Inside the `cms` folder, run these commands:
 #### 1. Schema extraction
 
 ```
-npx sanity schema extract --enforce-required-fields
+npx sanity schema extract
 ```
 
 ##### 2. Generate types from schema

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -19,9 +19,9 @@ const STUDIO_BASE_PATH = "/studio";
 
 //singleton pages. Before you add the type to singletontypes, the page should be created, since create is not a valid action for singleton types
 const PROJECT_ID = "0chpibsu";
-const DATASET = import.meta.env.VITE_SANITY_STUDIO_DATASET ?? "production";
+const DATASET = import.meta?.env?.VITE_SANITY_STUDIO_DATASET ?? "production";
 const SANITY_STUDIO_FRONTEND_URL =
-  import.meta.env.VITE_SANITY_STUDIO_FRONTEND_URL ??
+  import.meta?.env?.VITE_SANITY_STUDIO_FRONTEND_URL ??
   "https://bruddet.vercel.app";
 
 async function getDocumentPreviewUrl(


### PR DESCRIPTION
This was introduced after moving sanity into the remix project. The command still gives warnings, but otherwise works as expected.

## Endringstype.
- Bugfix.

## Lenke til notion
https://www.notion.so/bekks/Kanban-9d75804e327947458fd2550b89b31775?p=593b876755a74ae78393246686487a84&pm=s
