### PR TITLE
Add description to alt text field in Sanity.

### DIFF
--- a/cms/schemaTypes/objects/customImage.ts
+++ b/cms/schemaTypes/objects/customImage.ts
@@ -1,10 +1,10 @@
-import {defineField} from 'sanity'
-import {ImageIcon} from '@sanity/icons'
+import { defineField } from "sanity";
+import { ImageIcon } from "@sanity/icons";
 
 export default {
-  name: 'customImage',
-  title: 'Bilde',
-  type: 'image',
+  name: "customImage",
+  title: "Bilde",
+  type: "image",
   icon: ImageIcon,
   options: {
     hotspot: true,
@@ -12,10 +12,14 @@ export default {
 
   fields: [
     defineField({
-      title: 'Alternativ Tekst',
-      name: 'alt',
-      type: 'string',
-      validation: (rule) => [rule.required().min(1).error('Bildetekst er påkrevd')],
+      title: "Alternativ Tekst",
+      name: "alt",
+      type: "string",
+      description:
+        "Beskriv bildet for skjermlesere. Dette er påkrevd for å oppfylle webtilgjengelighetsstandarder(UU).",
+      validation: (rule) => [
+        rule.required().min(1).error("Bildetekst er påkrevd"),
+      ],
     }),
   ],
-}
+};


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/Kanban-9d75804e327947458fd2550b89b31775?p=ea7a450c8d2e40dd8f9d0c6c6a66ffc2&pm=s

## Beskrivelse.
Legger til beskrivelse av hva alt-tekst er

## Skjermbilder.
![image](https://github.com/user-attachments/assets/25a3a162-8158-4603-bdbc-9b5556d3bf12)
