### PR TITLE
Added null-checks in portable text component

### DIFF
--- a/app/components/PortableTextComponent.tsx
+++ b/app/components/PortableTextComponent.tsx
@@ -36,7 +36,7 @@ export default function PortableTextComponent({
       }>) => {
         return (
           <img
-            src={urlFor(value.asset._ref)}
+            src={urlFor(value.asset?._ref)}
             alt={value.alt}
             style={{ maxWidth: "100%" }}
           />
@@ -48,10 +48,10 @@ export default function PortableTextComponent({
         muxVideo: { asset: { playbackId: string } };
         title: string;
       }>) => {
-        return value.muxVideo.asset ? (
+        return value.muxVideo?.asset ? (
           <MuxPlayer
             disableCookies={true}
-            playbackId={stegaClean(value.muxVideo.asset.playbackId)}
+            playbackId={stegaClean(value.muxVideo.asset?.playbackId)}
             metadata={value.title ? { video_title: value.title } : undefined}
           />
         ) : null;

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -76,10 +76,10 @@ export type Review = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  type?: "dice" | "stars";
+  type: "dice" | "stars";
   score?: number;
-  content?: string;
-  source?: string;
+  content: string;
+  source: string;
   company?: string;
   link?: string;
   date?: string;
@@ -102,12 +102,12 @@ export type Video = {
   _updatedAt: string;
   _rev: string;
   title?: string;
-  muxVideo?: MuxVideo;
+  muxVideo: MuxVideo;
 };
 
 export type RoleGroups = {
   _type: "roleGroups";
-  name?: string;
+  name: string;
   persons?: Array<{
     person?: {
       _ref: string;
@@ -115,7 +115,7 @@ export type RoleGroups = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "person";
     };
-    occupation?: string;
+    occupation: string;
     _key: string;
   }>;
 };
@@ -146,34 +146,34 @@ export type Content = Array<{
   };
   hotspot?: SanityImageHotspot;
   crop?: SanityImageCrop;
-  alt?: string;
+  alt: string;
   _type: "customImage";
   _key: string;
 } | {
   title?: string;
-  muxVideo?: MuxVideo;
+  muxVideo: MuxVideo;
   _type: "video";
   _key: string;
 } | {
-  content?: string;
-  source?: string;
+  content: string;
+  source: string;
   company?: string;
   date?: string;
   _type: "quote";
   _key: string;
 } | {
-  type?: "dice" | "stars";
+  type: "dice" | "stars";
   score?: number;
-  content?: string;
-  source?: string;
+  content: string;
+  source: string;
   company?: string;
   link?: string;
   date?: string;
   _type: "review";
   _key: string;
 } | {
-  title?: string;
-  content?: string;
+  title: string;
+  content: string;
   _type: "expandableBlock";
   _key: string;
 }>;
@@ -184,8 +184,8 @@ export type ExpandableBlock = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  title?: string;
-  content?: string;
+  title: string;
+  content: string;
 };
 
 export type Quote = {
@@ -194,8 +194,8 @@ export type Quote = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  content?: string;
-  source?: string;
+  content: string;
+  source: string;
   company?: string;
   date?: string;
 };
@@ -399,10 +399,10 @@ export type Programpage = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  title?: string;
+  title: string;
   language?: string;
-  metaTitle?: MetaTitle;
-  metaDescription?: MetaDescription;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
   links?: Array<{
     _ref: string;
     _type: "reference";
@@ -419,7 +419,7 @@ export type Programpage = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   };
 };
@@ -430,10 +430,10 @@ export type Menupage = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  title?: string;
+  title: string;
   language?: string;
-  metaTitle?: MetaTitle;
-  metaDescription?: MetaDescription;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
   links?: Array<{
     _ref: string;
     _type: "reference";
@@ -449,9 +449,9 @@ export type Frontpage = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  title?: string;
+  title: string;
   language?: string;
-  image?: {
+  image: {
     asset?: {
       _ref: string;
       _type: "reference";
@@ -460,10 +460,10 @@ export type Frontpage = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   };
-  svgTitle?: {
+  svgTitle: {
     asset?: {
       _ref: string;
       _type: "reference";
@@ -472,7 +472,7 @@ export type Frontpage = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   };
   event?: {
@@ -481,8 +481,8 @@ export type Frontpage = {
     _weak?: boolean;
     [internalGroqTypeReferenceTo]?: "event";
   };
-  metaTitle?: MetaTitle;
-  metaDescription?: MetaDescription;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
 };
 
 export type Article = {
@@ -491,10 +491,10 @@ export type Article = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  title?: string;
+  title: string;
   language?: string;
-  colorCombinationsDay?: ColorCombinationsDay;
-  slug?: Slug;
+  colorCombinationsDay: ColorCombinationsDay;
+  slug: Slug;
   text?: Content;
   image?: {
     asset?: {
@@ -505,12 +505,12 @@ export type Article = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   };
   video?: {
     title?: string;
-    muxVideo?: MuxVideo;
+    muxVideo: MuxVideo;
     _type: "video";
   };
   event?: {
@@ -519,8 +519,8 @@ export type Article = {
     _weak?: boolean;
     [internalGroqTypeReferenceTo]?: "event";
   };
-  metaTitle?: MetaTitle;
-  metaDescription?: MetaDescription;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
 };
 
 export type Event = {
@@ -529,13 +529,13 @@ export type Event = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  title?: string;
+  title: string;
   language?: string;
   eventGenre?: EventGenre;
-  colorCombinationsNight?: ColorCombinationsNight;
+  colorCombinationsNight: ColorCombinationsNight;
   imageMask?: ImageMask;
-  slug?: Slug;
-  svgTitle?: {
+  slug: Slug;
+  svgTitle: {
     asset: {
       _ref: string;
       _type: "reference";
@@ -544,18 +544,18 @@ export type Event = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   };
   labels?: Array<string>;
-  dates?: Array<{
-    date?: string;
-    url?: string;
-    status?: 1 | 2 | 3;
+  dates: Array<{
+    date: string;
+    url: string;
+    status: 1 | 2 | 3;
     _key: string;
   }>;
-  duration?: string;
-  image?: {
+  duration: string;
+  image: {
     asset: {
       _ref: string;
       _type: "reference";
@@ -564,15 +564,15 @@ export type Event = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   };
   text?: Content;
   roleGroups?: Array<{
     _key: string;
   } & RoleGroups>;
-  metaTitle?: MetaTitle;
-  metaDescription?: MetaDescription;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
 };
 
 export type Person = {
@@ -581,9 +581,9 @@ export type Person = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  name?: string;
+  name: string;
   language?: string;
-  image?: {
+  image: {
     asset?: {
       _ref: string;
       _type: "reference";
@@ -592,7 +592,7 @@ export type Person = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   };
   text?: string;
@@ -608,12 +608,12 @@ export type CustomImage = {
   };
   hotspot?: SanityImageHotspot;
   crop?: SanityImageCrop;
-  alt?: string;
+  alt: string;
 };
 
 export type Slug = {
   _type: "slug";
-  current?: string;
+  current: string;
   source?: string;
 };
 
@@ -628,17 +628,17 @@ export declare const internalGroqTypeReferenceTo: unique symbol;
 // Query: *[_type=="article" && language==$lang]{_id, slug, title}
 export type ARTICLES_QUERYResult = Array<{
   _id: string;
-  slug: Slug | null;
-  title: string | null;
+  slug: Slug;
+  title: string;
 }>;
 // Variable: ARTICLE_QUERY
 // Query: *[_type=="article" && slug.current==$id && language==$lang][0]{    title,     slug,     metaTitle,     metaDescription,     colorCombinationsDay,     image,     text[]{...,       _type=="video" => {        title, muxVideo{asset->{playbackId}        }      }    },     video{      title,       muxVideo{        asset->{          playbackId}        }    },    'event': event->{slug},    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{      slug,      language,      }    }
 export type ARTICLE_QUERYResult = {
-  title: string | null;
-  slug: Slug | null;
-  metaTitle: MetaTitle | null;
-  metaDescription: MetaDescription | null;
-  colorCombinationsDay: ColorCombinationsDay | null;
+  title: string;
+  slug: Slug;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
+  colorCombinationsDay: ColorCombinationsDay;
   image: {
     asset?: {
       _ref: string;
@@ -648,7 +648,7 @@ export type ARTICLE_QUERYResult = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   } | null;
   text: Array<{
@@ -677,26 +677,26 @@ export type ARTICLE_QUERYResult = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
     _key: string;
   } | {
-    title?: string;
-    content?: string;
+    title: string;
+    content: string;
     _type: "expandableBlock";
     _key: string;
   } | {
-    content?: string;
-    source?: string;
+    content: string;
+    source: string;
     company?: string;
     date?: string;
     _type: "quote";
     _key: string;
   } | {
-    type?: "dice" | "stars";
+    type: "dice" | "stars";
     score?: number;
-    content?: string;
-    source?: string;
+    content: string;
+    source: string;
     company?: string;
     link?: string;
     date?: string;
@@ -706,7 +706,7 @@ export type ARTICLE_QUERYResult = {
     title: string | null;
     muxVideo: {
       asset: null;
-    } | null;
+    };
     _type: "video";
     _key: string;
   }> | null;
@@ -714,16 +714,16 @@ export type ARTICLE_QUERYResult = {
     title: string | null;
     muxVideo: {
       asset: null;
-    } | null;
+    };
   } | null;
   event: {
-    slug: Slug | null;
+    slug: Slug;
   } | null;
   _translations: Array<{
-    slug: null;
+    slug: Slug;
     language: string | null;
   } | {
-    slug: Slug | null;
+    slug: null;
     language: string | null;
   } | null>;
 } | null;
@@ -732,9 +732,9 @@ export type ARTICLE_QUERYResult = {
 // Variable: EVENT_QUERY
 // Query: *[_type=="event" && language==$lang && slug.current==$id][0]{    metaTitle,    metaDescription,    title,     image,    imageMask,     colorCombinationsNight,     dates,     labels,    text[]{..., _type=="video" => {title, muxVideo{asset->{playbackId}}}},    eventGenre,     roleGroups[]{      name,       persons[]{      occupation,       person->{name, image, text}      }    },    "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{    slug,    language,    }  }
 export type EVENT_QUERYResult = {
-  metaTitle: MetaTitle | null;
-  metaDescription: MetaDescription | null;
-  title: string | null;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
+  title: string;
   image: {
     asset: {
       _ref: string;
@@ -744,17 +744,17 @@ export type EVENT_QUERYResult = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
-  } | null;
+  };
   imageMask: ImageMask | null;
-  colorCombinationsNight: ColorCombinationsNight | null;
+  colorCombinationsNight: ColorCombinationsNight;
   dates: Array<{
-    date?: string;
-    url?: string;
-    status?: 1 | 2 | 3;
+    date: string;
+    url: string;
+    status: 1 | 2 | 3;
     _key: string;
-  }> | null;
+  }>;
   labels: Array<string> | null;
   text: Array<{
     children?: Array<{
@@ -782,26 +782,26 @@ export type EVENT_QUERYResult = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
     _key: string;
   } | {
-    title?: string;
-    content?: string;
+    title: string;
+    content: string;
     _type: "expandableBlock";
     _key: string;
   } | {
-    content?: string;
-    source?: string;
+    content: string;
+    source: string;
     company?: string;
     date?: string;
     _type: "quote";
     _key: string;
   } | {
-    type?: "dice" | "stars";
+    type: "dice" | "stars";
     score?: number;
-    content?: string;
-    source?: string;
+    content: string;
+    source: string;
     company?: string;
     link?: string;
     date?: string;
@@ -811,17 +811,17 @@ export type EVENT_QUERYResult = {
     title: string | null;
     muxVideo: {
       asset: null;
-    } | null;
+    };
     _type: "video";
     _key: string;
   }> | null;
   eventGenre: EventGenre | null;
   roleGroups: Array<{
-    name: string | null;
+    name: string;
     persons: Array<{
-      occupation: string | null;
+      occupation: string;
       person: {
-        name: string | null;
+        name: string;
         image: {
           asset?: {
             _ref: string;
@@ -831,18 +831,18 @@ export type EVENT_QUERYResult = {
           };
           hotspot?: SanityImageHotspot;
           crop?: SanityImageCrop;
-          alt?: string;
+          alt: string;
           _type: "customImage";
-        } | null;
+        };
         text: string | null;
       } | null;
     }> | null;
   }> | null;
   _translations: Array<{
-    slug: null;
+    slug: Slug;
     language: string | null;
   } | {
-    slug: Slug | null;
+    slug: null;
     language: string | null;
   } | null>;
 } | null;
@@ -851,7 +851,7 @@ export type EVENT_QUERYResult = {
 // Variable: FRONTPAGE_QUERY
 // Query: *[_type=="frontpage" && language==$lang][0]{  title,   image,   language,  svgTitle,   metaTitle,   metaDescription,   event->{    title,     text,     image,     slug,     metaTitle,     metaDescription,     svgTitle,    colorCombinationsNight    }  }
 export type FRONTPAGE_QUERYResult = {
-  title: string | null;
+  title: string;
   image: {
     asset?: {
       _ref: string;
@@ -861,9 +861,9 @@ export type FRONTPAGE_QUERYResult = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
-  } | null;
+  };
   language: string | null;
   svgTitle: {
     asset?: {
@@ -874,13 +874,13 @@ export type FRONTPAGE_QUERYResult = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
-  } | null;
-  metaTitle: MetaTitle | null;
-  metaDescription: MetaDescription | null;
+  };
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
   event: {
-    title: string | null;
+    title: string;
     text: Content | null;
     image: {
       asset: {
@@ -891,12 +891,12 @@ export type FRONTPAGE_QUERYResult = {
       };
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
-      alt?: string;
+      alt: string;
       _type: "customImage";
-    } | null;
-    slug: Slug | null;
-    metaTitle: MetaTitle | null;
-    metaDescription: MetaDescription | null;
+    };
+    slug: Slug;
+    metaTitle: MetaTitle;
+    metaDescription: MetaDescription;
     svgTitle: {
       asset: {
         _ref: string;
@@ -906,10 +906,10 @@ export type FRONTPAGE_QUERYResult = {
       };
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
-      alt?: string;
+      alt: string;
       _type: "customImage";
-    } | null;
-    colorCombinationsNight: ColorCombinationsNight | null;
+    };
+    colorCombinationsNight: ColorCombinationsNight;
   } | null;
 } | null;
 
@@ -917,13 +917,13 @@ export type FRONTPAGE_QUERYResult = {
 // Variable: MENUPAGE_QUERY
 // Query: *[_type=="menupage" && language==$lang]{title, metaTitle, metaDescription, links[]->{_type, title, slug}}[0]
 export type MENUPAGE_QUERYResult = {
-  title: string | null;
-  metaTitle: MetaTitle | null;
-  metaDescription: MetaDescription | null;
+  title: string;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
   links: Array<{
     _type: "article";
-    title: string | null;
-    slug: Slug | null;
+    title: string;
+    slug: Slug;
   }> | null;
 } | null;
 
@@ -931,9 +931,9 @@ export type MENUPAGE_QUERYResult = {
 // Variable: PROGRAMPAGE_QUERY
 // Query: *[_type=="programpage" && language==$lang]{metaTitle, metaDescription, title, text,gif, links[]->{title, slug, gif, image, dates} }[0]
 export type PROGRAMPAGE_QUERYResult = {
-  metaTitle: MetaTitle | null;
-  metaDescription: MetaDescription | null;
-  title: string | null;
+  metaTitle: MetaTitle;
+  metaDescription: MetaDescription;
+  title: string;
   text: null;
   gif: {
     asset?: {
@@ -944,12 +944,12 @@ export type PROGRAMPAGE_QUERYResult = {
     };
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    alt?: string;
+    alt: string;
     _type: "customImage";
   } | null;
   links: Array<{
-    title: string | null;
-    slug: Slug | null;
+    title: string;
+    slug: Slug;
     gif: null;
     image: {
       asset: {
@@ -960,15 +960,15 @@ export type PROGRAMPAGE_QUERYResult = {
       };
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
-      alt?: string;
+      alt: string;
       _type: "customImage";
-    } | null;
+    };
     dates: Array<{
-      date?: string;
-      url?: string;
-      status?: 1 | 2 | 3;
+      date: string;
+      url: string;
+      status: 1 | 2 | 3;
       _key: string;
-    }> | null;
+    }>;
   }> | null;
 } | null;
 

--- a/schema.json
+++ b/schema.json
@@ -392,7 +392,7 @@
             }
           ]
         },
-        "optional": true
+        "optional": false
       },
       "score": {
         "type": "objectAttribute",
@@ -406,14 +406,14 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "source": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "company": {
         "type": "objectAttribute",
@@ -555,7 +555,7 @@
           "type": "inline",
           "name": "mux.video"
         },
-        "optional": true
+        "optional": false
       }
     }
   },
@@ -577,7 +577,7 @@
           "value": {
             "type": "string"
           },
-          "optional": true
+          "optional": false
         },
         "persons": {
           "type": "objectAttribute",
@@ -621,7 +621,7 @@
                   "value": {
                     "type": "string"
                   },
-                  "optional": true
+                  "optional": false
                 }
               },
               "rest": {
@@ -868,7 +868,7 @@
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "_type": {
                 "type": "objectAttribute",
@@ -906,7 +906,7 @@
                   "type": "inline",
                   "name": "mux.video"
                 },
-                "optional": true
+                "optional": false
               },
               "_type": {
                 "type": "objectAttribute",
@@ -936,14 +936,14 @@
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "source": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "company": {
                 "type": "objectAttribute",
@@ -997,7 +997,7 @@
                     }
                   ]
                 },
-                "optional": true
+                "optional": false
               },
               "score": {
                 "type": "objectAttribute",
@@ -1011,14 +1011,14 @@
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "source": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "company": {
                 "type": "objectAttribute",
@@ -1069,14 +1069,14 @@
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "content": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "_type": {
                 "type": "objectAttribute",
@@ -1142,14 +1142,14 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "content": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       }
     }
   },
@@ -1193,14 +1193,14 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "source": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "company": {
         "type": "objectAttribute",
@@ -2360,7 +2360,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "language": {
         "type": "objectAttribute",
@@ -2375,7 +2375,7 @@
           "type": "inline",
           "name": "metaTitle"
         },
-        "optional": true
+        "optional": false
       },
       "metaDescription": {
         "type": "objectAttribute",
@@ -2383,7 +2383,7 @@
           "type": "inline",
           "name": "metaDescription"
         },
-        "optional": true
+        "optional": false
       },
       "links": {
         "type": "objectAttribute",
@@ -2485,7 +2485,7 @@
               "value": {
                 "type": "string"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -2540,7 +2540,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "language": {
         "type": "objectAttribute",
@@ -2555,7 +2555,7 @@
           "type": "inline",
           "name": "metaTitle"
         },
-        "optional": true
+        "optional": false
       },
       "metaDescription": {
         "type": "objectAttribute",
@@ -2563,7 +2563,7 @@
           "type": "inline",
           "name": "metaDescription"
         },
-        "optional": true
+        "optional": false
       },
       "links": {
         "type": "objectAttribute",
@@ -2651,7 +2651,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "language": {
         "type": "objectAttribute",
@@ -2716,7 +2716,7 @@
               "value": {
                 "type": "string"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -2727,7 +2727,7 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       },
       "svgTitle": {
         "type": "objectAttribute",
@@ -2785,7 +2785,7 @@
               "value": {
                 "type": "string"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -2796,7 +2796,7 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       },
       "event": {
         "type": "objectAttribute",
@@ -2834,7 +2834,7 @@
           "type": "inline",
           "name": "metaTitle"
         },
-        "optional": true
+        "optional": false
       },
       "metaDescription": {
         "type": "objectAttribute",
@@ -2842,7 +2842,7 @@
           "type": "inline",
           "name": "metaDescription"
         },
-        "optional": true
+        "optional": false
       }
     }
   },
@@ -2886,7 +2886,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "language": {
         "type": "objectAttribute",
@@ -2901,7 +2901,7 @@
           "type": "inline",
           "name": "colorCombinationsDay"
         },
-        "optional": true
+        "optional": false
       },
       "slug": {
         "type": "objectAttribute",
@@ -2909,7 +2909,7 @@
           "type": "inline",
           "name": "slug"
         },
-        "optional": true
+        "optional": false
       },
       "text": {
         "type": "objectAttribute",
@@ -2975,7 +2975,7 @@
               "value": {
                 "type": "string"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -3006,7 +3006,7 @@
                 "type": "inline",
                 "name": "mux.video"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -3055,7 +3055,7 @@
           "type": "inline",
           "name": "metaTitle"
         },
-        "optional": true
+        "optional": false
       },
       "metaDescription": {
         "type": "objectAttribute",
@@ -3063,7 +3063,7 @@
           "type": "inline",
           "name": "metaDescription"
         },
-        "optional": true
+        "optional": false
       }
     }
   },
@@ -3107,7 +3107,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "language": {
         "type": "objectAttribute",
@@ -3130,7 +3130,7 @@
           "type": "inline",
           "name": "colorCombinationsNight"
         },
-        "optional": true
+        "optional": false
       },
       "imageMask": {
         "type": "objectAttribute",
@@ -3146,7 +3146,7 @@
           "type": "inline",
           "name": "slug"
         },
-        "optional": true
+        "optional": false
       },
       "svgTitle": {
         "type": "objectAttribute",
@@ -3204,7 +3204,7 @@
               "value": {
                 "type": "string"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -3215,7 +3215,7 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       },
       "labels": {
         "type": "objectAttribute",
@@ -3239,14 +3239,14 @@
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "url": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string"
                 },
-                "optional": true
+                "optional": false
               },
               "status": {
                 "type": "objectAttribute",
@@ -3267,7 +3267,7 @@
                     }
                   ]
                 },
-                "optional": true
+                "optional": false
               }
             },
             "rest": {
@@ -3283,14 +3283,14 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       },
       "duration": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "image": {
         "type": "objectAttribute",
@@ -3348,7 +3348,7 @@
               "value": {
                 "type": "string"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -3359,7 +3359,7 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       },
       "text": {
         "type": "objectAttribute",
@@ -3397,7 +3397,7 @@
           "type": "inline",
           "name": "metaTitle"
         },
-        "optional": true
+        "optional": false
       },
       "metaDescription": {
         "type": "objectAttribute",
@@ -3405,7 +3405,7 @@
           "type": "inline",
           "name": "metaDescription"
         },
-        "optional": true
+        "optional": false
       }
     }
   },
@@ -3449,7 +3449,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "language": {
         "type": "objectAttribute",
@@ -3514,7 +3514,7 @@
               "value": {
                 "type": "string"
               },
-              "optional": true
+              "optional": false
             },
             "_type": {
               "type": "objectAttribute",
@@ -3525,7 +3525,7 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       },
       "text": {
         "type": "objectAttribute",
@@ -3600,7 +3600,7 @@
           "value": {
             "type": "string"
           },
-          "optional": true
+          "optional": false
         }
       }
     }
@@ -3623,7 +3623,7 @@
           "value": {
             "type": "string"
           },
-          "optional": true
+          "optional": false
         },
         "source": {
           "type": "objectAttribute",


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Link til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=1acd376d397748c1a49cecae44c61ead&pm=s

## Beskrivelse.
Hvis man la til bilder/videoer i portabletextcomponent i en artikkel i preview, ville preview-siden krasje før man lastet opp filen. Dette gjaldt bilder og videoer i portabletext i preview. La til nullsjekk.

Har prøvd å teste flere felter i forskjellige sidetyper i preview, men har ikke funnet noe annet som krasjer enda.
