### PR TITLE
Update fetching of environment variables in sanity config.

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -19,10 +19,9 @@ const STUDIO_BASE_PATH = "/studio";
 
 //singleton pages. Before you add the type to singletontypes, the page should be created, since create is not a valid action for singleton types
 const PROJECT_ID = "0chpibsu";
-const DATASET = import.meta?.env?.VITE_SANITY_STUDIO_DATASET ?? "production";
+const DATASET = process.env.VITE_SANITY_STUDIO_DATASET ?? "production";
 const SANITY_STUDIO_FRONTEND_URL =
-  import.meta?.env?.VITE_SANITY_STUDIO_FRONTEND_URL ??
-  "https://bruddet.vercel.app";
+  process.env.VITE_SANITY_STUDIO_FRONTEND_URL ?? "https://bruddet.vercel.app";
 
 async function getDocumentPreviewUrl(
   document: SanityDocumentLike,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,30 @@
 import { vitePlugin as remix } from "@remix-run/dev";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
-  plugins: [
-    remix({
-      future: {
-        v3_fetcherPersist: true,
-        v3_relativeSplatPath: true,
-        v3_throwAbortReason: true,
-      },
-    }),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    define: {
+      //This pattern is needed to make env variables available in sanity.config.ts.
+      "process.env.VITE_SANITY_STUDIO_DATASET": JSON.stringify(
+        env.VITE_SANITY_STUDIO_DATASET
+      ),
+      "process.env.VITE_SANITY_STUDIO_FRONTEND_URL": JSON.stringify(
+        env.VITE_SANITY_STUDIO_FRONTEND_URL
+      ),
+    },
 
-    tsconfigPaths(),
-  ],
+    plugins: [
+      remix({
+        future: {
+          v3_fetcherPersist: true,
+          v3_relativeSplatPath: true,
+          v3_throwAbortReason: true,
+        },
+      }),
+
+      tsconfigPaths(),
+    ],
+  };
 });


### PR DESCRIPTION
Sanity wants to get environment variables process.env, while building with Vite doesn't allow this by default, and instead uses import.meta.env. This commit adds only the necessary environment variables to process.env.

## Endringstype.
- Bugfix.
