### PR TITLE
Add portable text to expandable content.

### DIFF
--- a/app/components/ExpandableBlockComponent.tsx
+++ b/app/components/ExpandableBlockComponent.tsx
@@ -2,17 +2,25 @@ import { motion } from "framer-motion";
 import { useState } from "react";
 import ArrowDown from "../assets/arrow-down.svg";
 import { createTexts, useTranslation } from "~/utils/i18n";
+import PortableTextComponent, {
+  PortableTextProps,
+} from "./PortableTextComponent";
 
 type Props = {
   title: string;
-  children: React.ReactNode;
+  content: PortableTextProps;
+  textStyle?: string;
 };
 
-export const ExpandableBlockComponent = ({ title, children }: Props) => {
+export const ExpandableBlockComponent = ({
+  title,
+  content,
+  textStyle,
+}: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const { t } = useTranslation();
-
   const buttonVariants = { clicked: { rotate: 180 } };
+
   return (
     <div className="border self-start w-full my-4">
       <button
@@ -42,7 +50,12 @@ export const ExpandableBlockComponent = ({ title, children }: Props) => {
         style={{ overflow: "hidden" }}
       >
         <div className="mx-4 mb-4">
-          <div className="flex flex-row mt-4 gap-6">{children}</div>
+          <div className="flex flex-row mt-4 gap-6">
+            <PortableTextComponent
+              textData={content}
+              textStyle={textStyle}
+            ></PortableTextComponent>
+          </div>
         </div>
       </motion.div>
     </div>

--- a/app/components/PortableTextComponent.tsx
+++ b/app/components/PortableTextComponent.tsx
@@ -14,7 +14,7 @@ interface QuoteStyle {
   fillColor?: string;
 }
 
-interface PortableTextProps extends QuoteStyle {
+export interface PortableTextProps extends QuoteStyle {
   textData: CustomContent;
   textStyle?: string;
 }
@@ -105,11 +105,17 @@ export default function PortableTextComponent({
       },
       expandableBlock: ({
         value,
-      }: PortableTextComponentProps<{ title: string; content: string }>) => {
+      }: PortableTextComponentProps<{
+        title: string;
+        content: string;
+        textStyle: string;
+      }>) => {
         return (
-          <ExpandableBlockComponent title={value.title}>
-            {value.content}
-          </ExpandableBlockComponent>
+          <ExpandableBlockComponent
+            title={value.title}
+            textStyle={textStyle}
+            content={value.content}
+          ></ExpandableBlockComponent>
         );
       },
     },

--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -16,6 +16,7 @@ import eventGenre from "./objects/eventGenre";
 import { programpage } from "./programpage";
 import { expandableBlockType } from "./objects/expandableBlockType";
 import { menuPage } from "./menupage";
+import expandableContent from "./objects/expandableContent";
 
 export const schemaTypes = [
   articleType,
@@ -26,6 +27,7 @@ export const schemaTypes = [
   menuPage,
   quoteType,
   expandableBlockType,
+  expandableContent,
   RichTextEditor,
   roleGroups,
   videoType,

--- a/cms/schemaTypes/objects/expandableBlockType.ts
+++ b/cms/schemaTypes/objects/expandableBlockType.ts
@@ -5,6 +5,11 @@ export const expandableBlockType = defineType({
   name: "expandableBlock",
   title: "Ekspanderbar blokk",
   type: "document",
+  preview: {
+    select: {
+      title: "title",
+    },
+  },
   icon: BlockElementIcon,
   fields: [
     defineField({
@@ -18,7 +23,7 @@ export const expandableBlockType = defineType({
     }),
     defineField({
       name: "content",
-      type: "text",
+      type: "expandableContent",
       title: "Innhold",
       validation: (rule) => [
         rule.required().min(2).error(`Innhold er påkrevd`),

--- a/cms/schemaTypes/objects/expandableContent.ts
+++ b/cms/schemaTypes/objects/expandableContent.ts
@@ -1,0 +1,20 @@
+export default {
+  name: "expandableContent",
+  type: "array",
+  title: "Content",
+  of: [
+    {
+      type: "block",
+      styles: [
+        { title: "Normal", value: "normal" },
+        { title: "Heading 3", value: "h3" },
+        { title: "Heading 4", value: "h4" },
+        { title: "Heading 5", value: "h5" },
+        { title: "Heading 6", value: "h6" },
+      ],
+    },
+    {
+      type: "customImage",
+    },
+  ],
+};

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -172,8 +172,68 @@ export type Content = Array<{
   _key: string;
 } | {
   title?: string;
-  content?: string;
+  content?: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal" | "h3" | "h4" | "h5" | "h6";
+    listItem?: "bullet" | "number";
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  } | {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    _type: "customImage";
+    _key: string;
+  }>;
   _type: "expandableBlock";
+  _key: string;
+}>;
+
+export type ExpandableContent = Array<{
+  children?: Array<{
+    marks?: Array<string>;
+    text?: string;
+    _type: "span";
+    _key: string;
+  }>;
+  style?: "normal" | "h3" | "h4" | "h5" | "h6";
+  listItem?: "bullet" | "number";
+  markDefs?: Array<{
+    href?: string;
+    _type: "link";
+    _key: string;
+  }>;
+  level?: number;
+  _type: "block";
+  _key: string;
+} | {
+  asset?: {
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+  };
+  hotspot?: SanityImageHotspot;
+  crop?: SanityImageCrop;
+  alt?: string;
+  _type: "customImage";
   _key: string;
 }>;
 
@@ -184,7 +244,7 @@ export type ExpandableBlock = {
   _updatedAt: string;
   _rev: string;
   title?: string;
-  content?: string;
+  content?: ExpandableContent;
 };
 
 export type Quote = {
@@ -628,7 +688,7 @@ export type InternationalizedArrayReference = Array<{
   _key: string;
 } & InternationalizedArrayReferenceValue>;
 
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | EventGenre | Review | ImageMask | ColorCombinations | MetaDescription | MetaTitle | Video | RoleGroups | Content | ExpandableBlock | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MediaTag | MuxVideo | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Programpage | Menupage | Frontpage | Article | Event | Person | CustomImage | Slug | InternationalizedArrayReference;
+export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | EventGenre | Review | ImageMask | ColorCombinations | MetaDescription | MetaTitle | Video | RoleGroups | Content | ExpandableContent | ExpandableBlock | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MediaTag | MuxVideo | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Programpage | Menupage | Frontpage | Article | Event | Person | CustomImage | Slug | InternationalizedArrayReference;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./app/queries/article-queries.ts
 // Variable: ARTICLES_QUERY
@@ -691,7 +751,36 @@ export type ARTICLE_QUERYResult = {
     _key: string;
   } | {
     title?: string;
-    content?: string;
+    content?: Array<{
+      children?: Array<{
+        marks?: Array<string>;
+        text?: string;
+        _type: "span";
+        _key: string;
+      }>;
+      style?: "h3" | "h4" | "h5" | "h6" | "normal";
+      listItem?: "bullet" | "number";
+      markDefs?: Array<{
+        href?: string;
+        _type: "link";
+        _key: string;
+      }>;
+      level?: number;
+      _type: "block";
+      _key: string;
+    } | {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "customImage";
+      _key: string;
+    }>;
     _type: "expandableBlock";
     _key: string;
   } | {
@@ -799,7 +888,36 @@ export type EVENT_QUERYResult = {
     _key: string;
   } | {
     title?: string;
-    content?: string;
+    content?: Array<{
+      children?: Array<{
+        marks?: Array<string>;
+        text?: string;
+        _type: "span";
+        _key: string;
+      }>;
+      style?: "h3" | "h4" | "h5" | "h6" | "normal";
+      listItem?: "bullet" | "number";
+      markDefs?: Array<{
+        href?: string;
+        _type: "link";
+        _key: string;
+      }>;
+      level?: number;
+      _type: "block";
+      _key: string;
+    } | {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "customImage";
+      _key: string;
+    }>;
     _type: "expandableBlock";
     _key: string;
   } | {

--- a/schema.json
+++ b/schema.json
@@ -1072,7 +1072,248 @@
               "content": {
                 "type": "objectAttribute",
                 "value": {
-                  "type": "string"
+                  "type": "array",
+                  "of": {
+                    "type": "union",
+                    "of": [
+                      {
+                        "type": "object",
+                        "attributes": {
+                          "children": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "array",
+                              "of": {
+                                "type": "object",
+                                "attributes": {
+                                  "marks": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                      "type": "array",
+                                      "of": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "optional": true
+                                  },
+                                  "text": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "optional": true
+                                  },
+                                  "_type": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                      "type": "string",
+                                      "value": "span"
+                                    }
+                                  }
+                                },
+                                "rest": {
+                                  "type": "object",
+                                  "attributes": {
+                                    "_key": {
+                                      "type": "objectAttribute",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "optional": true
+                          },
+                          "style": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "union",
+                              "of": [
+                                {
+                                  "type": "string",
+                                  "value": "normal"
+                                },
+                                {
+                                  "type": "string",
+                                  "value": "h3"
+                                },
+                                {
+                                  "type": "string",
+                                  "value": "h4"
+                                },
+                                {
+                                  "type": "string",
+                                  "value": "h5"
+                                },
+                                {
+                                  "type": "string",
+                                  "value": "h6"
+                                }
+                              ]
+                            },
+                            "optional": true
+                          },
+                          "listItem": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "union",
+                              "of": [
+                                {
+                                  "type": "string",
+                                  "value": "bullet"
+                                },
+                                {
+                                  "type": "string",
+                                  "value": "number"
+                                }
+                              ]
+                            },
+                            "optional": true
+                          },
+                          "markDefs": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "array",
+                              "of": {
+                                "type": "object",
+                                "attributes": {
+                                  "href": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "optional": true
+                                  },
+                                  "_type": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                      "type": "string",
+                                      "value": "link"
+                                    }
+                                  }
+                                },
+                                "rest": {
+                                  "type": "object",
+                                  "attributes": {
+                                    "_key": {
+                                      "type": "objectAttribute",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "optional": true
+                          },
+                          "level": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "number"
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "block"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "attributes": {
+                          "asset": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "object",
+                              "attributes": {
+                                "_ref": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "_type": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string",
+                                    "value": "reference"
+                                  }
+                                },
+                                "_weak": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "boolean"
+                                  },
+                                  "optional": true
+                                }
+                              },
+                              "dereferencesTo": "sanity.imageAsset"
+                            },
+                            "optional": true
+                          },
+                          "hotspot": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "inline",
+                              "name": "sanity.imageHotspot"
+                            },
+                            "optional": true
+                          },
+                          "crop": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "inline",
+                              "name": "sanity.imageCrop"
+                            },
+                            "optional": true
+                          },
+                          "alt": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "customImage"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
                 },
                 "optional": true
               },
@@ -1081,6 +1322,254 @@
                 "value": {
                   "type": "string",
                   "value": "expandableBlock"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "expandableContent",
+    "type": "type",
+    "value": {
+      "type": "array",
+      "of": {
+        "type": "union",
+        "of": [
+          {
+            "type": "object",
+            "attributes": {
+              "children": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "marks": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "array",
+                          "of": {
+                            "type": "string"
+                          }
+                        },
+                        "optional": true
+                      },
+                      "text": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "span"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "style": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "normal"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h3"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h4"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h5"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h6"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "listItem": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "bullet"
+                    },
+                    {
+                      "type": "string",
+                      "value": "number"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "markDefs": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "href": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "link"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "level": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "number"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "block"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "attributes": {
+              "asset": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "sanity.imageAsset"
+                },
+                "optional": true
+              },
+              "hotspot": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageHotspot"
+                },
+                "optional": true
+              },
+              "crop": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageCrop"
+                },
+                "optional": true
+              },
+              "alt": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "customImage"
                 }
               }
             },
@@ -1145,7 +1634,8 @@
       "content": {
         "type": "objectAttribute",
         "value": {
-          "type": "string"
+          "type": "inline",
+          "name": "expandableContent"
         },
         "optional": true
       }


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=30501da5c21c49a29afcc2030d7d2afd&pm=s

## Beskrivelse.
Legger til mulighet for portable text med bilder i ekspanderbar blokk. Dette gir flere muligheter for å styre innholdet i ekspanderbar blokk.

## Skjermbilder.
![image](https://github.com/user-attachments/assets/74b314d3-c92f-4ae5-8cd6-229a05df4bb7)
![image](https://github.com/user-attachments/assets/0d7c5b59-00cd-4a70-8e0b-291fc25ad9bf)

