### PR TITLE
Legg til kredittering på bilder

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useState } from "react";
 import PurpleDot from "~/assets/PurpleDot";
 import { createTexts, useTranslation } from "~/utils/i18n";
@@ -34,19 +33,19 @@ export function Footer({ bgColor }: FooterProps) {
         {displayText ? (
           <>
             <div className="py-4 whitespace-nowrap animate-marquee ">
-              {Array.from({ length: 30 }).map((_, i) => (
-                <React.Fragment key={i}>
+              {Array.from({ length: 30 }).map(() => (
+                <>
                   <span className="text-xl mx-4">{t(texts.marqueeText)}</span>
                   <PurpleDot />
-                </React.Fragment>
+                </>
               ))}
             </div>
             <div className="absolute top-0 py-4 animate-marquee2 whitespace-nowrap">
-              {Array.from({ length: 30 }).map((_, i) => (
-                <React.Fragment key={i}>
+              {Array.from({ length: 30 }).map(() => (
+                <>
                   <span className="text-xl mx-4">{t(texts.marqueeText)}</span>
                   <PurpleDot />
-                </React.Fragment>
+                </>
               ))}
             </div>
           </>

--- a/app/components/PortableTextComponent.tsx
+++ b/app/components/PortableTextComponent.tsx
@@ -33,13 +33,18 @@ export default function PortableTextComponent({
       }: PortableTextComponentProps<{
         asset: { _ref: string; _type: "reference" };
         alt: string;
+        credit: string;
       }>) => {
         return (
-          <img
-            src={urlFor(value.asset?._ref)}
-            alt={value.alt}
-            style={{ maxWidth: "100%" }}
-          />
+          <>
+            <img
+              src={urlFor(value.asset._ref)}
+              alt={value.alt}
+              style={{ maxWidth: "100%" }}
+              className="mb-1"
+            />
+            <p className="mt-1">{value.credit}</p>
+          </>
         );
       },
       video: ({

--- a/cms/schemaTypes/objects/customImage.ts
+++ b/cms/schemaTypes/objects/customImage.ts
@@ -21,5 +21,10 @@ export default {
         rule.required().min(1).error("Bildetekst er påkrevd"),
       ],
     }),
+    defineField({
+      title: "Bildekreditering",
+      name: "credit",
+      type: "string",
+    }),
   ],
 };

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -147,6 +147,7 @@ export type Content = Array<{
   hotspot?: SanityImageHotspot;
   crop?: SanityImageCrop;
   alt?: string;
+  credit?: string;
   _type: "customImage";
   _key: string;
 } | {
@@ -420,6 +421,7 @@ export type Programpage = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   };
 };
@@ -461,6 +463,7 @@ export type Frontpage = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   };
   svgTitle?: {
@@ -473,6 +476,7 @@ export type Frontpage = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   };
   event?: {
@@ -506,6 +510,7 @@ export type Article = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   };
   video?: {
@@ -543,6 +548,7 @@ export type Event = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   };
   imageMask?: ImageMask;
@@ -557,6 +563,7 @@ export type Event = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   };
   dates?: Array<{
@@ -593,6 +600,7 @@ export type Person = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   };
   text?: string;
@@ -609,6 +617,7 @@ export type CustomImage = {
   hotspot?: SanityImageHotspot;
   crop?: SanityImageCrop;
   alt?: string;
+  credit?: string;
 };
 
 export type Slug = {
@@ -649,6 +658,7 @@ export type ARTICLE_QUERYResult = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   } | null;
   text: Array<{
@@ -678,6 +688,7 @@ export type ARTICLE_QUERYResult = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
     _key: string;
   } | {
@@ -745,6 +756,7 @@ export type EVENT_QUERYResult = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   } | null;
   imageMask: ImageMask | null;
@@ -784,6 +796,7 @@ export type EVENT_QUERYResult = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
     _key: string;
   } | {
@@ -833,6 +846,7 @@ export type EVENT_QUERYResult = {
           hotspot?: SanityImageHotspot;
           crop?: SanityImageCrop;
           alt?: string;
+          credit?: string;
           _type: "customImage";
         } | null;
         text: string | null;
@@ -863,6 +877,7 @@ export type FRONTPAGE_QUERYResult = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   } | null;
   language: string | null;
@@ -876,6 +891,7 @@ export type FRONTPAGE_QUERYResult = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   } | null;
   metaTitle: MetaTitle | null;
@@ -893,6 +909,7 @@ export type FRONTPAGE_QUERYResult = {
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       alt?: string;
+      credit?: string;
       _type: "customImage";
     } | null;
     slug: Slug | null;
@@ -908,6 +925,7 @@ export type FRONTPAGE_QUERYResult = {
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       alt?: string;
+      credit?: string;
       _type: "customImage";
     } | null;
     colorCombinationsNight: ColorCombinationsNight | null;
@@ -946,6 +964,7 @@ export type PROGRAMPAGE_QUERYResult = {
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     alt?: string;
+    credit?: string;
     _type: "customImage";
   } | null;
   links: Array<{
@@ -962,6 +981,7 @@ export type PROGRAMPAGE_QUERYResult = {
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       alt?: string;
+      credit?: string;
       _type: "customImage";
     } | null;
     dates: Array<{

--- a/schema.json
+++ b/schema.json
@@ -870,6 +870,13 @@
                 },
                 "optional": true
               },
+              "credit": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
               "_type": {
                 "type": "objectAttribute",
                 "value": {
@@ -2487,6 +2494,13 @@
               },
               "optional": true
             },
+            "credit": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
             "_type": {
               "type": "objectAttribute",
               "value": {
@@ -2718,6 +2732,13 @@
               },
               "optional": true
             },
+            "credit": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
             "_type": {
               "type": "objectAttribute",
               "value": {
@@ -2781,6 +2802,13 @@
               "optional": true
             },
             "alt": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "credit": {
               "type": "objectAttribute",
               "value": {
                 "type": "string"
@@ -2971,6 +2999,13 @@
               "optional": true
             },
             "alt": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "credit": {
               "type": "objectAttribute",
               "value": {
                 "type": "string"
@@ -3190,6 +3225,13 @@
               },
               "optional": true
             },
+            "credit": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
             "_type": {
               "type": "objectAttribute",
               "value": {
@@ -3269,6 +3311,13 @@
               "optional": true
             },
             "alt": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "credit": {
               "type": "objectAttribute",
               "value": {
                 "type": "string"
@@ -3516,6 +3565,13 @@
               },
               "optional": true
             },
+            "credit": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
             "_type": {
               "type": "objectAttribute",
               "value": {
@@ -3596,6 +3652,13 @@
           "optional": true
         },
         "alt": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "credit": {
           "type": "objectAttribute",
           "value": {
             "type": "string"


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=108cb73ebe624ddf95ff098cd6115354&pm=s

## Beskrivelse.
Legger til kredittering på bilder. I sanity er dette et tekstfelt, og i Remix legges det til en p-tag som har informasjonen. Kanskje denne teksten bør skille seg litt mer fra annen tekst?

## Skjermbilder.
![image](https://github.com/user-attachments/assets/b5dbc364-1773-4478-9742-a41202735834)
