### PR TITLE
Remove animation when navigating between pages.

### DIFF
--- a/app/components/StickyFooter.tsx
+++ b/app/components/StickyFooter.tsx
@@ -39,7 +39,7 @@ export default function StickyFooter({
 
   return (
     <footer
-      className={`w-full bottom-0 sticky border-t text-${textcolor} ${color} font-serif text-2xl border-${textcolor} shadow py-2  z-10 `}
+      className={`w-full bottom-0 mt-auto sticky border-t text-${textcolor} ${color} font-serif text-2xl border-${textcolor} shadow py-2  z-10 `}
     >
       <ul className="flex flex-row justify-center">
         <li>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,8 +14,6 @@ import StickyFooter from "./components/StickyFooter";
 import Header from "./components/Header/Header";
 import PageNotFound from "./components/PageNotFound";
 import { LoaderFunction } from "@remix-run/node";
-import { motion } from "framer-motion";
-import { usePageTransition } from "./utils/pageTransition";
 import {
   getLanguageFromPath,
   LanguageProvider,
@@ -111,7 +109,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  const { slideDirection, pathname } = usePageTransition();
   const { language, preview } = useRouteLoaderData<typeof loader>("root");
   const location = useLocation();
 
@@ -128,25 +125,14 @@ export default function App() {
               <ExitPreview />
             </Suspense>
           )}
-          <Header />
-          <LanguageButton />
-          <motion.div
-            className="flex flex-col min-h-[100vh]"
-            key={pathname}
-            initial={{ x: slideDirection * 100 + "%" }}
-            animate={{ x: 0 }}
-            exit={{
-              x: slideDirection * -100 + "%",
-            }}
-            transition={{
-              duration: 0.5,
-            }}
-          >
+          <div className="min-h-[100vh] flex flex-col">
+            <Header />
+            <LanguageButton />
             <div id="main">
               <Outlet />
             </div>
-          </motion.div>
-          <StickyFooter menyUrl="/meny" programUrl="/program" />
+            <StickyFooter menyUrl="/meny" programUrl="/program" />
+          </div>
         </SlugProvider>
       </BackgroundColorProvider>
     </LanguageProvider>


### PR DESCRIPTION
Also fixes issue with pages using up more than the entire page.

## Endringstype.
- Refaktorering.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=1036bd3085418004b08cdf7461eba286&pm=s

## Beskrivelse.
Siden "slide" animasjon/transisjon ikke ble helt som ønsket av design, så skal de fjernes helt. I tillegg så fikses her feilen med at programside og meny alltid tar opp mer enn hele siden, slik at man kan scrolle.
