### PR TITLE
Use marks property to determine if text should be displayed as bold

### DIFF
--- a/app/components/PortableTextComponent.tsx
+++ b/app/components/PortableTextComponent.tsx
@@ -49,13 +49,20 @@ export default function PortableTextComponent({
       block: ({
         value,
       }: PortableTextComponentProps<{
-        children: { text: string }[];
+        children: { text: string, marks: string[] }[];
       }>) => {
         return (
           <div className={!placedLeft ? "sm:hidden" : " leading-6 "}>
-            {value.children.map((child, i) => (
+            <>
+            {value.children.filter(v => v.marks.includes("strong")).map((child, i) => (
+              <b key={i}>{child.text}</b>
+            ))}
+            </>
+            <>
+            {value.children.filter(v => v.marks.length === 0).map((child, i) => (
               <p key={i}>{child.text}</p>
             ))}
+            </>
           </div>
         );
       },


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/Fj-reheia-boardet-9d75804e327947458fd2550b89b31775?p=1066bd3085418064ac67cca88c4a0a4d&pm=s

## Beskrivelse.
Bruker et felt som sendes med portable text, for å definere hvordan innholdet skal ses ut. Dette er hovedsaklig en POC, som viser hvordan det kan løses. Gjøres det på denne måten, må man gjøre tilsvarende for alle skrifttyper vi ønsker å støtte i portable text.

Jeg prøvde først å løse det på måten beskrevet i dokumentasjonen her: https://www.sanity.io/docs/portable-text-to-react. Men det fikk jeg ikke til å fungere. 

## Skjermbilder.
<img width="464" alt="image" src="https://github.com/user-attachments/assets/e22b7df1-7a8f-4133-acc9-114cddb3738f">

