### PR TITLE
fontsize adjustments for quotebomb, and credits

### DIFF
--- a/app/components/PortableTextComponent.tsx
+++ b/app/components/PortableTextComponent.tsx
@@ -88,8 +88,16 @@ export default function PortableTextComponent({
         value,
       }: PortableTextComponentProps<{
         quote: string;
+        creditsSource?: string;
+        creditsMedia?: string;
       }>) => {
-        return <QuoteBomb quote={value.quote} />;
+        return (
+          <QuoteBomb
+            quote={value.quote}
+            creditsMedia={value.creditsMedia}
+            creditsSource={value.creditsSource}
+          />
+        );
       },
     },
   };

--- a/app/components/QuoteBomb.tsx
+++ b/app/components/QuoteBomb.tsx
@@ -1,26 +1,57 @@
+import { stegaClean } from "@sanity/client/stega";
+
 type Props = {
   quote: string;
+  creditsSource?: string;
+  creditsMedia?: string;
 };
-export const QuoteBomb = ({ quote }: Props) => {
-  const lengthOfString = quote.length;
+export const QuoteBomb = ({ quote, creditsMedia, creditsSource }: Props) => {
+  const cleanQuote = stegaClean(quote);
+  const lengthOfString = cleanQuote.length;
 
   const getFontSize = () => {
-    if (lengthOfString < 20) {
-      return "120px";
-    } else if (lengthOfString > 20 && lengthOfString < 40) {
-      return "90px";
-    } else if (lengthOfString > 40 && lengthOfString < 60) {
+    if (lengthOfString < 30) {
+      return "80px";
+    } else if (lengthOfString >= 30 && lengthOfString < 45) {
       return "70px";
+    } else if (lengthOfString >= 45 && lengthOfString < 60) {
+      return "55px";
+    } else if (lengthOfString >= 60 && lengthOfString < 80) {
+      return "45px";
+    } else if (lengthOfString >= 80 && lengthOfString < 90) {
+      return "40px";
+    } else if (lengthOfString >= 90 && lengthOfString < 100) {
+      return "35px";
     } else {
-      return "60px";
+      return "20px";
     }
   };
+
+  const getLineHeight = () => {
+    if (lengthOfString < 30) {
+      return "70px";
+    } else if (lengthOfString >= 30 && lengthOfString < 45) {
+      return "55px";
+    } else if (lengthOfString >= 45 && lengthOfString < 60) {
+      return "50px";
+    } else if (lengthOfString >= 60 && lengthOfString < 80) {
+      return "45px";
+    } else if (lengthOfString >= 80 && lengthOfString < 90) {
+      return "40px";
+    } else if (lengthOfString >= 85 && lengthOfString < 100) {
+      return "35px";
+    } else {
+      return "20px";
+    }
+  };
+
   const fontSize = getFontSize();
+  const lineHeight = getLineHeight();
+
   return (
     <div>
       <svg
         width="474"
-        height="360"
         viewBox="0 0 474 360"
         fill="none"
         style={{ maxWidth: "100%" }}
@@ -41,14 +72,19 @@ export const QuoteBomb = ({ quote }: Props) => {
               display: "flex",
               alignItems: "center",
               height: "100%",
+              lineHeight: lineHeight,
             }}
           >
-            <p style={{ margin: "0", padding: "0", lineHeight: "70px" }}>
-              {quote}
-            </p>
+            <p style={{ margin: "0", padding: "0" }}>{quote}</p>
           </div>
         </foreignObject>
       </svg>
+      {(creditsMedia || creditsSource) && (
+        <div className="flex flex-col font-bold items-center my-8">
+          <p>{creditsSource}</p>
+          <p>{creditsMedia}</p>
+        </div>
+      )}
     </div>
   );
 };

--- a/cms/schemaTypes/objects/quoteBomb.ts
+++ b/cms/schemaTypes/objects/quoteBomb.ts
@@ -15,5 +15,15 @@ export default {
         "OBS: redaktør må selv passe på ord-deling for at det skal se bra ut, da figuren ikke tilpasser seg tekst.",
       validation: (rule) => [rule.max(100).warning("Anbefaler kortere quote.")],
     }),
+    defineField({
+      title: "Kreditering - person",
+      name: "creditsSource",
+      type: "string",
+    }),
+    defineField({
+      title: "Kreditering - media/rolle",
+      name: "creditsMedia",
+      type: "string",
+    }),
   ],
 };

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -75,6 +75,8 @@ export type QuoteBomb = {
   _updatedAt: string;
   _rev: string;
   quote?: string;
+  creditsSource?: string;
+  creditsMedia?: string;
 };
 
 export type EventGenre = "Konsert" | "Skuespill";
@@ -207,6 +209,8 @@ export type Content = Array<{
   _key: string;
 } | {
   quote?: string;
+  creditsSource?: string;
+  creditsMedia?: string;
   _type: "quoteBomb";
   _key: string;
 }>;
@@ -781,6 +785,8 @@ export type ARTICLE_QUERYResult = {
     _key: string;
   } | {
     quote?: string;
+    creditsSource?: string;
+    creditsMedia?: string;
     _type: "quoteBomb";
     _key: string;
   } | {
@@ -930,6 +936,8 @@ export type EVENT_QUERYResult = {
     _key: string;
   } | {
     quote?: string;
+    creditsSource?: string;
+    creditsMedia?: string;
     _type: "quoteBomb";
     _key: string;
   } | {

--- a/schema.json
+++ b/schema.json
@@ -366,6 +366,20 @@
           "type": "string"
         },
         "optional": true
+      },
+      "creditsSource": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "creditsMedia": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
       }
     }
   },
@@ -1312,6 +1326,20 @@
             "type": "object",
             "attributes": {
               "quote": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "creditsSource": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "creditsMedia": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string"


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Link til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=10d6bd308541805f86f4c58719fd49eb&pm=s

## Beskrivelse.
La til mulighet for kreditering på quotebomb. Fikset også at fontstørrelse faktisk oppdaterer seg basert på antall tegn.

## Skjermbilder.
![image](https://github.com/user-attachments/assets/67b3ceb9-5bf2-4016-a449-6019cb6e8dba)
