### PR TITLE
Window-bug

### DIFF
--- a/app/routes/($lang).event.$id.tsx
+++ b/app/routes/($lang).event.$id.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { Custom_EVENT_QUERYResult } from "../../cms/customTypes";
@@ -162,7 +162,9 @@ export default function Event() {
               colorCombination={colorCombination}
             />
           )}
-          <EventTextContent textColor={primaryTextColor} data={data} />
+          <Suspense>
+            <EventTextContent textColor={primaryTextColor} data={data} />
+          </Suspense>
         </div>
       </div>
       <BuyButtonFooter handleScroll={handleScroll} />


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Beskrivelse.
Ved refresh på event-side fikk man en feilmelding som var relatert til at man brukte "window.". Wrappet komponent i Suspense for å unngå feilen som en midlertidig fiks.
OBS: dette gjør at vi mister server-side rendering, så alternative løsninger kan vurderes senere.

