### PR TITLE
video and quotebomb in left column

### DIFF
--- a/app/components/EventTextContent.tsx
+++ b/app/components/EventTextContent.tsx
@@ -8,19 +8,19 @@ type Props = {
   data: Custom_EVENT_QUERYResult;
 };
 
-export const activeGallerySlideClassName = `absolute mt-5 opacity-1 transition-opacity duration-400 ease-linear delay-400 gallery-slide`;
+export const activeGallerySlideClassName = `absolute mt-5 opacity-1 transition-opacity duration-400 ease-linear delay-400 gallery-slide w-[30em] h-[20em]`;
 export const inactiveGallerySlideClassName = `mt-5 opacity-0 gallery-slide`;
 
 export const EventTextContent = ({ textColor, data }: Props) => {
-  const leftBlockTypes = ["block", "review"];
-
-  const rightBlockTypes = [
-    "quoteBomb",
-    "expandableBlock",
-    "dice",
+  const leftBlockTypes = [
+    "block",
+    "review",
     "video",
-    "customImage",
+    "expandableBlock",
+    "quoteBomb",
   ];
+
+  const rightBlockSickyTypes = ["customImage"];
 
   const galleryDisplayType = data.galleryDisplayType;
 
@@ -28,9 +28,10 @@ export const EventTextContent = ({ textColor, data }: Props) => {
     swapActiveImage();
   };
 
-  const rightBlocks = data?.text.filter((block) =>
-    rightBlockTypes.includes(block._type)
+  const stickyRightBlocks = data?.text.filter((block) =>
+    rightBlockSickyTypes.includes(block._type)
   );
+
   const leftBlocks = data?.text.filter((block) =>
     leftBlockTypes.includes(block._type)
   );
@@ -47,6 +48,7 @@ export const EventTextContent = ({ textColor, data }: Props) => {
       {/*grid-block for regular screens*/}
       <div className="hidden md:block">
         <div className="grid grid-cols-2 gap-10 font-serif text-xl">
+          {/*left-column*/}
           <div className="flex justify-start w-full">
             <div className="lg:w-4/5 flex flex-col gap-8">
               {leftBlocks.map((d, index) => (
@@ -59,9 +61,10 @@ export const EventTextContent = ({ textColor, data }: Props) => {
               <RolesAndTickets roleGroups={data?.roleGroups} data={data} />
             </div>
           </div>
+          {/*right-column*/}
           <div className="flex justify-end w-full">
             <div className={galleryClassName}>
-              {rightBlocks?.map((d, index) => (
+              {stickyRightBlocks?.map((d, index) => (
                 <div
                   className={
                     galleryDisplayType != 1

--- a/app/components/PortableTextComponent.tsx
+++ b/app/components/PortableTextComponent.tsx
@@ -26,12 +26,8 @@ export default function PortableTextComponent({
         credit: string;
       }>) => {
         return (
-          <div className="md:py-10 w-[100%]">
-            <img
-              className="min-w-[100%]"
-              src={urlFor(value.asset._ref)}
-              alt={value.alt}
-            />
+          <div className="md:py-10">
+            <img src={urlFor(value.asset._ref)} alt={value.alt} />
             <p className="mt-1">{value.credit}</p>
           </div>
         );

--- a/app/components/QuoteBomb.tsx
+++ b/app/components/QuoteBomb.tsx
@@ -54,7 +54,7 @@ export const QuoteBomb = ({ quote, creditsMedia, creditsSource }: Props) => {
         width="474"
         viewBox="0 0 474 360"
         fill="none"
-        style={{ maxWidth: "100%" }}
+        style={{ maxWidth: "15em" }}
         xmlns="http://www.w3.org/2000/svg"
       >
         <path


### PR DESCRIPTION
## Endringstype.
- Design

## Link til oppgave (Notion).
https://www.notion.so/bekks/Kolonner-sitatbombe-skal-v-re-skilt-ut-fra-bildekarusell-og-vises-under-bilder-Videoer-skal-flytt-1266bd308541803ba848cf2479bec86b?pvs=4

## Beskrivelse.
Flyttet video og quotebomb til venstre kolonne, så bare bilder er i bildegalleri i høyre kolonne.

## Skjermbilder.
<img width="636" alt="Screenshot 2024-10-22 at 11 28 07" src="https://github.com/user-attachments/assets/533e873f-74c6-4f7a-a31e-9435277717b2">

<img width="963" alt="Screenshot 2024-10-22 at 11 29 33" src="https://github.com/user-attachments/assets/276dac99-5992-4ed1-828c-ce62261c9557">
